### PR TITLE
Issue/30

### DIFF
--- a/src/crudeditor-lib/components/Main/index.js
+++ b/src/crudeditor-lib/components/Main/index.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import { connect } from '../../connectExtended';
 import ViewSwitcher from '../ViewSwitcher';
 import { hardRedirectView } from '../../common/actions';
 

--- a/src/crudeditor-lib/components/ViewSwitcher/index.js
+++ b/src/crudeditor-lib/components/ViewSwitcher/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import { connect } from '../../connectExtended';
 
 import SearchView from '../../views/search/container';
 import CreateView from '../../views/create/container';

--- a/src/crudeditor-lib/connectExtended.js
+++ b/src/crudeditor-lib/connectExtended.js
@@ -1,0 +1,22 @@
+import { connect, createProvider } from 'react-redux'
+
+const STORE_KEY = 'react-crudeditor'
+
+export const Provider = createProvider(STORE_KEY)
+
+function connectExtended(
+  mapStateToProps,
+  mapDispatchToProps,
+  mergeProps,
+  options = {}
+) {
+  options.storeKey = STORE_KEY
+  return connect(
+    mapStateToProps,
+    mapDispatchToProps,
+    mergeProps,
+    options
+  )
+}
+
+export {connectExtended as connect}

--- a/src/crudeditor-lib/connectExtended.js
+++ b/src/crudeditor-lib/connectExtended.js
@@ -10,7 +10,7 @@ function connectExtended(
   mergeProps,
   options = {}
 ) {
-  options.storeKey = STORE_KEY
+  options.storeKey = STORE_KEY // eslint-disable-line no-param-reassign
   return connect(
     mapStateToProps,
     mapDispatchToProps,
@@ -19,4 +19,4 @@ function connectExtended(
   )
 }
 
-export {connectExtended as connect}
+export { connectExtended as connect }

--- a/src/crudeditor-lib/index.js
+++ b/src/crudeditor-lib/index.js
@@ -145,7 +145,7 @@ export default baseModelDefinition => {
         ))
       );
 
-      this.runningSaga = sagaMiddleware.run(rootSaga, modelDefinition);
+      this.crudSaga = sagaMiddleware.run(rootSaga, modelDefinition);
 
       this.initI18n(props);
     }
@@ -177,7 +177,7 @@ export default baseModelDefinition => {
     }) => !isEqual(storeState2appState(this.store.getState()), { name, state })
 
     componentWillUnmount() {
-      this.runningSaga.cancel()
+      this.crudSaga.cancel()
     }
 
     // create our own i18n context

--- a/src/crudeditor-lib/index.js
+++ b/src/crudeditor-lib/index.js
@@ -127,11 +127,9 @@ export default baseModelDefinition => {
 
     constructor(props, context) {
       super(props, context);
-      console.log('crud constructor called')
 
       onTransition = this.props.onTransition;
 
-      console.log('create store')
       this.store = createStore(
         getReducer(modelDefinition),
         (window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose)(applyMiddleware(
@@ -146,9 +144,9 @@ export default baseModelDefinition => {
           sagaMiddleware
         ))
       );
-    
+
       this.runningSaga = sagaMiddleware.run(rootSaga, modelDefinition);
-      
+
       this.initI18n(props);
     }
 
@@ -176,11 +174,10 @@ export default baseModelDefinition => {
         name = DEFAULT_VIEW,
         state = {}
       } = {}
-    }) => !isEqual(storeState2appState(store.getState()), { name, state })
+    }) => !isEqual(storeState2appState(this.store.getState()), { name, state })
 
     componentWillUnmount() {
       this.runningSaga.cancel()
-      // this.store = null
     }
 
     // create our own i18n context

--- a/src/crudeditor-lib/middleware/appStateChangeDetect.js
+++ b/src/crudeditor-lib/middleware/appStateChangeDetect.js
@@ -5,7 +5,8 @@ import { STATUS_READY } from '../common/constants';
 export default ({
   lastState,
   onTransition,
-  storeState2appState
+  storeState2appState,
+  modelDefinition
 }) => ({ getState }) => next => action => {
   const rez = next(action);
   const storeState = getState();
@@ -28,10 +29,10 @@ export default ({
   }
 
   if (lastState.store && !lastState.app) {
-    lastState.app = storeState2appState(lastState.store); // eslint-disable-line no-param-reassign
+    lastState.app = storeState2appState(lastState.store, modelDefinition); // eslint-disable-line no-param-reassign
   }
 
-  const appState = storeState2appState(storeState);
+  const appState = storeState2appState(storeState, modelDefinition);
 
   if (!isEqual(appState, lastState.app)) {
     onTransition(appState);

--- a/src/crudeditor-lib/views/create/container.js
+++ b/src/crudeditor-lib/views/create/container.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { connect } from 'react-redux';
+import { connect } from '../../connectExtended';
 import Main from '../../../components/CreateMain';
 import { getViewModelData } from './selectors';
 

--- a/src/crudeditor-lib/views/edit/container.js
+++ b/src/crudeditor-lib/views/edit/container.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { connect } from 'react-redux';
+import { connect } from '../../connectExtended';
 import Main from '../../../components/EditMain';
 import { getViewModelData } from './selectors';
 import { deleteInstances } from '../../common/actions';

--- a/src/crudeditor-lib/views/error/container.js
+++ b/src/crudeditor-lib/views/error/container.js
@@ -1,6 +1,6 @@
 // Edit View container component.
 import React from 'react';
-import { connect } from 'react-redux';
+import { connect } from '../../connectExtended';
 
 import Main from '../../../components/ErrorMain';
 import { getViewModelData } from './selectors';

--- a/src/crudeditor-lib/views/search/container.js
+++ b/src/crudeditor-lib/views/search/container.js
@@ -1,6 +1,6 @@
 // Edit View container component.
 import React from 'react';
-import { connect } from 'react-redux';
+import { connect } from '../../connectExtended';
 import Main from '../../../components/SearchMain';
 import { createInstance } from '../create/actions';
 import { editInstance } from '../edit/actions';

--- a/src/crudeditor-lib/views/show/container.js
+++ b/src/crudeditor-lib/views/show/container.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { connect } from 'react-redux'
+import { connect } from '../../connectExtended'
 
 import Main from '../../../components/ShowMain'
 import { getViewModelData } from './selectors'


### PR DESCRIPTION
My vision on possible improvements / fixes for issue #30.

Looks like the reason Redux store persists after Crud unmounts is that Redux store is created is Crud's closure ([this line](https://github.com/OpusCapita/react-crudeditor/blob/master/src/crudeditor-lib/index.js#L100)). I believe we should move `createStore` block and sagas' `run` call into Crud's [constructor](https://github.com/OpusCapita/react-crudeditor/blob/Issue/30/src/crudeditor-lib/index.js#L133). In this case store is created anew when navigating back to previously loaded and unmounted crud, and is also destroyed as a class property during crud's unmount phase.

Also, as another store incapsulation method (maybe no really nesessary), we can give this store a unique name (which is 'store' [by default](https://github.com/reactjs/react-redux/blob/master/docs/api.md#provider-store) for all redux instances, so there can possibly arise a conflict in multi-store apps): 

> connect(..., [options])
> [storeKey] (String): The key of the context from where to read the store. You probably only need this if you are in the inadvisable position of having multiple stores. Default value: 'store'
> 
> createProvider([storeKey])
> Creates a new <Provider> which will set the Redux Store on the passed key of the context. You probably only need this if you are in the inadvisable position of having multiple stores. You will also need to pass the same storeKey to the options argument of connect

Both things are implemented in this pull request.

**Please review it before considering a merge.** This is a possible solution, but not nesessarily the fix, and should be tested in environment where the error is reproducable.