### PR TITLE
Added webpack definePlugin to lib build config.

### DIFF
--- a/config/webpack.config.build.js
+++ b/config/webpack.config.build.js
@@ -79,7 +79,6 @@ module.exports = {
     ]
   },
   plugins: [
-    new webpack.NamedModulesPlugin(),
     new webpack.optimize.ModuleConcatenationPlugin(),
     new webpack.NoEmitOnErrorsPlugin(),
     new webpack.DefinePlugin({

--- a/config/webpack.config.build.js
+++ b/config/webpack.config.build.js
@@ -81,6 +81,9 @@ module.exports = {
   plugins: [
     new webpack.NamedModulesPlugin(),
     new webpack.optimize.ModuleConcatenationPlugin(),
-    new webpack.NoEmitOnErrorsPlugin()
+    new webpack.NoEmitOnErrorsPlugin(),
+    new webpack.DefinePlugin({
+      'process.env.NODE_ENV': JSON.stringify('production')
+    })
   ]
 };


### PR DESCRIPTION
#26 

Added 'production' NODE_ENV declaration and removed `NamedModulesPlugin` from production build (saves ~10% of the bundle size).