### PR TITLE
Implemented basic permissions system for crud's schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "base-64": "0.1.0",
     "big.js": "3.1.3",
     "lodash": "4.17.4",
-    "prop-types": "15.5.10",
+    "prop-types": "^15.6.0",
     "react-bootstrap": "0.31.1",
     "react-notifications": "1.4.3",
     "react-redux": "5.0.5",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "base-64": "0.1.0",
     "big.js": "3.1.3",
     "lodash": "4.17.4",
-    "prop-types": "^15.6.0",
+    "prop-types": "15.5.10",
     "react-bootstrap": "0.31.1",
     "react-notifications": "1.4.3",
     "react-redux": "5.0.5",

--- a/src/components/EditHeading/index.js
+++ b/src/components/EditHeading/index.js
@@ -36,7 +36,10 @@ export default class EditHeading extends PureComponent {
           tabs,
           viewName,
           persistentInstance,
-          formInstance
+          formInstance,
+          permissions: {
+            crudOperations
+          }
         },
         actions: {
           selectTab,
@@ -87,9 +90,11 @@ export default class EditHeading extends PureComponent {
           <Col xs={4}>
             <div style={{ float: "right" }}>
               <ButtonGroup>
-                <Button bsStyle='link' onClick={exitView}>
-                  {i18n.getMessage('crudEditor.search.result.label')}
-                </Button>
+                { crudOperations.view &&
+                  <Button bsStyle='link' onClick={exitView}>
+                    {i18n.getMessage('crudEditor.search.result.label')}
+                  </Button>
+                }
                 {arrowLeft}
                 {arrowRight}
               </ButtonGroup>

--- a/src/components/EditTab/index.js
+++ b/src/components/EditTab/index.js
@@ -27,7 +27,10 @@ class EditTab extends React.PureComponent {
         data: {
           viewName,
           persistentInstance,
-          formInstance
+          formInstance,
+          permissions: {
+            crudOperations
+          }
         }
       },
       fieldErrorsWrapper: {
@@ -40,13 +43,17 @@ class EditTab extends React.PureComponent {
 
     const disableSave = (formInstance && isEqual(persistentInstance, formInstance));
 
-    const buttons = [
-      <Button bsStyle='link' onClick={exitView} key="Cancel">
-        {this.context.i18n.getMessage('crudEditor.cancel.button')}
-      </Button>
-    ];
+    const buttons = [];
 
-    if (viewName === VIEW_EDIT) {
+    if (crudOperations.view) {
+      buttons.push(
+        <Button bsStyle='link' onClick={exitView} key="Cancel">
+          {this.context.i18n.getMessage('crudEditor.cancel.button')}
+        </Button>
+      )
+    }
+
+    if (viewName === VIEW_EDIT && crudOperations.delete) {
       buttons.push(
         <ConfirmDialog
           trigger='click'
@@ -69,7 +76,7 @@ class EditTab extends React.PureComponent {
         </Button>)
     }
 
-    if (~[VIEW_CREATE, VIEW_EDIT].indexOf(viewName)) {
+    if (~[VIEW_CREATE, VIEW_EDIT].indexOf(viewName) && crudOperations.create) {
       buttons.push(
         <Button
           onClick={handleSaveAndNew}

--- a/src/components/SearchBulkOperationsPanel/index.js
+++ b/src/components/SearchBulkOperationsPanel/index.js
@@ -1,46 +1,58 @@
-import React from 'react';
+import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { Button } from 'react-bootstrap';
 
 import ConfirmDialog from '../ConfirmDialog';
 import './SearchBulkOperationsPanel.less';
 
-class SearchBulkOperationsPanel extends React.PureComponent {
+export default class SearchBulkOperationsPanel extends PureComponent {
+  static propTypes = {
+    model: PropTypes.shape({
+      data: PropTypes.shape({
+        selectedInstances: PropTypes.array,
+        permissions: PropTypes.shape({
+          crudOperations: PropTypes.shape({
+            delete: PropTypes.bool.isRequired
+          })
+        })
+      }),
+      actions: PropTypes.objectOf(PropTypes.func)
+    }).isRequired
+  }
+
+  static contextTypes = {
+    i18n: PropTypes.object
+  };
+
   handleDelete = _ => this.props.model.actions.deleteInstances(this.props.model.data.selectedInstances)
 
-  render = _ =>
-    (<div className='crud---search-bulk-operations-panel'>
-      <div>
-        <ConfirmDialog
-          trigger='click'
-          title='Delete confirmation'
-          onConfirm={this.handleDelete}
-          message={this.context.i18n.getMessage('crudEditor.deleteSelected.confirmation')}
-          textConfirm={this.context.i18n.getMessage('crudEditor.delete.button')}
-          textCancel={this.context.i18n.getMessage('crudEditor.cancel.button')}
-        >
-          <Button bsSize='sm' disabled={this.props.model.data.selectedInstances.length === 0}>
-            {this.context.i18n.getMessage('crudEditor.deleteSelected.button')}
-          </Button>
-        </ConfirmDialog>
+  render() {
+    const { i18n } = this.context;
+    const canDelete = this.props.model.data.permissions.crudOperations.delete;
+
+    return (
+      <div className='crud---search-bulk-operations-panel'>
+        {
+          canDelete && (<div>
+            <ConfirmDialog
+              trigger='click'
+              title='Delete confirmation'
+              onConfirm={this.handleDelete}
+              message={i18n.getMessage('crudEditor.deleteSelected.confirmation')}
+              textConfirm={i18n.getMessage('crudEditor.delete.button')}
+              textCancel={i18n.getMessage('crudEditor.cancel.button')}
+            >
+              <Button bsSize='sm' disabled={this.props.model.data.selectedInstances.length === 0}>
+                {i18n.getMessage('crudEditor.deleteSelected.button')}
+              </Button>
+            </ConfirmDialog>
+          </div>)
+        }
+        <div>
+          {/* export menu here*/}
+        </div>
       </div>
-      <div>
-        {/* export menu here*/}
-      </div>
-    </div>)
+    )
+  }
 }
 
-SearchBulkOperationsPanel.propTypes = {
-  model: PropTypes.shape({
-    data: PropTypes.shape({
-      selectedInstances: PropTypes.array
-    }),
-    actions: PropTypes.objectOf(PropTypes.func)
-  }).isRequired
-}
-
-SearchBulkOperationsPanel.contextTypes = {
-  i18n: PropTypes.object
-};
-
-export default SearchBulkOperationsPanel;

--- a/src/components/SearchMain/index.js
+++ b/src/components/SearchMain/index.js
@@ -5,7 +5,22 @@ import Result from '../SearchResult';
 import { getModelMessage } from '../lib'
 import './SearchMain.less';
 
-class SearchMain extends PureComponent {
+export default class SearchMain extends PureComponent {
+  static propTypes = {
+    model: PropTypes.shape({
+      actions: PropTypes.objectOf(PropTypes.func),
+      data: PropTypes.shape({
+        permissions: PropTypes.shape({
+          crudOperations: PropTypes.object.isRequired
+        })
+      })
+    }).isRequired
+  }
+
+  static contextTypes = {
+    i18n: PropTypes.object
+  };
+
   handleCreate = (e) => {
     this.props.model.actions.createInstance();
   }
@@ -13,6 +28,7 @@ class SearchMain extends PureComponent {
   render() {
     const { model } = this.props;
     const { i18n } = this.context;
+    const canCreate = model.data.permissions.crudOperations.create;
 
     return (
       <div className="crud--search-main">
@@ -20,13 +36,15 @@ class SearchMain extends PureComponent {
           <h3 className="crud--search-main__page-title">
             {i18n.getMessage('crudEditor.search.header', { "payload": getModelMessage(i18n, 'model.name') })}
           </h3>
-          <button
-            type="button"
-            className="btn btn-sm btn-primary"
-            onClick={this.handleCreate}
-          >
-            {i18n.getMessage('crudEditor.create.button')}
-          </button>
+          { canCreate &&
+            <button
+              type="button"
+              className="btn btn-sm btn-primary"
+              onClick={this.handleCreate}
+            >
+              {i18n.getMessage('crudEditor.create.button')}
+            </button>
+          }
         </div>
 
         <div className="crud--search-main__container">
@@ -42,15 +60,3 @@ class SearchMain extends PureComponent {
     );
   }
 }
-
-SearchMain.propTypes = {
-  model: PropTypes.shape({
-    actions: PropTypes.objectOf(PropTypes.func)
-  }).isRequired
-}
-
-SearchMain.contextTypes = {
-  i18n: PropTypes.object
-};
-
-export default SearchMain;

--- a/src/components/SearchResultListing/SearchResultButtons.js
+++ b/src/components/SearchResultListing/SearchResultButtons.js
@@ -1,0 +1,79 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import { Glyphicon, Button, ButtonGroup } from 'react-bootstrap';
+import ConfirmDialog from '../ConfirmDialog';
+
+export default class SearchResultButtons extends PureComponent {
+  static propTypes = {
+    model: PropTypes.shape({
+      data: PropTypes.shape({
+        permissions: PropTypes.shape({
+          crudOperations: PropTypes.object.isRequired
+        })
+      })
+    }),
+    instance: PropTypes.object,
+    index: PropTypes.number,
+    onShow: PropTypes.func,
+    onEdit: PropTypes.func,
+    onDelete: PropTypes.func
+  }
+
+  static contextTypes = {
+    i18n: PropTypes.object.isRequired
+  }
+
+  render() {
+    const permissions = this.props.model.data.permissions.crudOperations;
+    const {
+      instance,
+      index,
+      onShow,
+      onEdit,
+      onDelete
+    } = this.props;
+    const { i18n } = this.context;
+
+    const showButton = permissions.view && !permissions.edit ?
+      (<Button onClick={onShow(instance, index)}>
+        <Glyphicon glyph='glyphicon-eye-open' />
+        {' '}
+        {i18n.getMessage('crudEditor.show.button')}
+      </Button>) :
+      null;
+
+    const editButton = permissions.edit ?
+      (<Button onClick={onEdit(instance, index)}>
+        <Glyphicon glyph='edit' />
+        {' '}
+        {i18n.getMessage('crudEditor.edit.button')}
+      </Button>) :
+      null;
+
+    const deleteButton = permissions.delete ?
+      (<ConfirmDialog
+        trigger='click'
+        onConfirm={onDelete(instance)}
+        title='Delete confirmation'
+        message={i18n.getMessage('crudEditor.delete.confirmation')}
+        textConfirm={i18n.getMessage('crudEditor.delete.button')}
+        textCancel={i18n.getMessage('crudEditor.cancel.button')}
+      >
+        <Button>
+          <Glyphicon glyph='trash' />
+          {' '}
+          {i18n.getMessage('crudEditor.delete.button')}
+        </Button>
+      </ConfirmDialog>) :
+      null;
+
+    return showButton || editButton || deleteButton ? (
+      <ButtonGroup bsSize="sm" className="crud--search-result-listing__action-buttons">
+        {showButton}
+        {editButton}
+        {deleteButton}
+      </ButtonGroup>
+    ) :
+      null;
+  }
+}

--- a/src/components/SearchResultListing/SearchResultButtons.js
+++ b/src/components/SearchResultListing/SearchResultButtons.js
@@ -30,22 +30,20 @@ export default class SearchResultButtons extends PureComponent {
 
     const buttons = [];
 
-    if (permissions.view && !permissions.edit) {
-      buttons.push(
-        <Button onClick={onShow} key="show">
-          <Glyphicon glyph='glyphicon-eye-open' />
-          {' '}
-          {i18n.getMessage('crudEditor.show.button')}
-        </Button>
-      )
-    }
-
     if (permissions.edit) {
       buttons.push(
         <Button onClick={onEdit} key="edit">
           <Glyphicon glyph='edit' />
           {' '}
           {i18n.getMessage('crudEditor.edit.button')}
+        </Button>
+      )
+    } else if (permissions.view) {
+      buttons.push(
+        <Button onClick={onShow} key="show">
+          <Glyphicon glyph='glyphicon-eye-open' />
+          {' '}
+          {i18n.getMessage('crudEditor.show.button')}
         </Button>
       )
     }

--- a/src/components/SearchResultListing/SearchResultButtons.js
+++ b/src/components/SearchResultListing/SearchResultButtons.js
@@ -25,55 +25,55 @@ export default class SearchResultButtons extends PureComponent {
 
   render() {
     const permissions = this.props.model.data.permissions.crudOperations;
-    const {
-      instance,
-      index,
-      onShow,
-      onEdit,
-      onDelete
-    } = this.props;
+    const { onShow, onEdit, onDelete } = this.props;
     const { i18n } = this.context;
 
-    const showButton = permissions.view && !permissions.edit ?
-      (<Button onClick={onShow(instance, index)}>
-        <Glyphicon glyph='glyphicon-eye-open' />
-        {' '}
-        {i18n.getMessage('crudEditor.show.button')}
-      </Button>) :
-      null;
+    const buttons = [];
 
-    const editButton = permissions.edit ?
-      (<Button onClick={onEdit(instance, index)}>
-        <Glyphicon glyph='edit' />
-        {' '}
-        {i18n.getMessage('crudEditor.edit.button')}
-      </Button>) :
-      null;
-
-    const deleteButton = permissions.delete ?
-      (<ConfirmDialog
-        trigger='click'
-        onConfirm={onDelete(instance)}
-        title='Delete confirmation'
-        message={i18n.getMessage('crudEditor.delete.confirmation')}
-        textConfirm={i18n.getMessage('crudEditor.delete.button')}
-        textCancel={i18n.getMessage('crudEditor.cancel.button')}
-      >
-        <Button>
-          <Glyphicon glyph='trash' />
+    if (permissions.view && !permissions.edit) {
+      buttons.push(
+        <Button onClick={onShow} key="show">
+          <Glyphicon glyph='glyphicon-eye-open' />
           {' '}
-          {i18n.getMessage('crudEditor.delete.button')}
+          {i18n.getMessage('crudEditor.show.button')}
         </Button>
-      </ConfirmDialog>) :
-      null;
+      )
+    }
 
-    return showButton || editButton || deleteButton ? (
+    if (permissions.edit) {
+      buttons.push(
+        <Button onClick={onEdit} key="edit">
+          <Glyphicon glyph='edit' />
+          {' '}
+          {i18n.getMessage('crudEditor.edit.button')}
+        </Button>
+      )
+    }
+
+    if (permissions.delete) {
+      buttons.push(
+        <ConfirmDialog
+          trigger='click'
+          onConfirm={onDelete}
+          title='Delete confirmation'
+          message={i18n.getMessage('crudEditor.delete.confirmation')}
+          textConfirm={i18n.getMessage('crudEditor.delete.button')}
+          textCancel={i18n.getMessage('crudEditor.cancel.button')}
+          key="delete"
+        >
+          <Button>
+            <Glyphicon glyph='trash' />
+            {' '}
+            {i18n.getMessage('crudEditor.delete.button')}
+          </Button>
+        </ConfirmDialog>
+      )
+    }
+
+    return buttons.length > 0 && (
       <ButtonGroup bsSize="sm" className="crud--search-result-listing__action-buttons">
-        {showButton}
-        {editButton}
-        {deleteButton}
+        {buttons}
       </ButtonGroup>
-    ) :
-      null;
+    );
   }
 }

--- a/src/components/SearchResultListing/index.js
+++ b/src/components/SearchResultListing/index.js
@@ -102,74 +102,76 @@ class SearchResultListing extends PureComponent {
                 </th>
               }
 
-              {resultFields.map(({ name, sortable }) =>
-                (<th key={`th-${name}`}>
-                  {
-                    sortable ?
-                      <a
-                        className="crud--search-result-listing__sort-button"
-                        style={{ cursor: "pointer", whiteSpace: "nowrap" }}
-                        onClick={this.handleResort(name)}
-                      >
-                        {getModelMessage(i18n, `model.field.${name}`, name)}
-                        {
-                          sortField === name &&
-                          <Glyphicon
-                            className="crud--search-result-listing__sort-icon"
-                            glyph={`arrow-${sortOrder === 'asc' ? 'down' : 'up'}`}
-                          />
-                        }
-                      </a> :
-                      getModelMessage(i18n, `model.field.${name}`, name)
-                  }
-                </th>)
-              )}
+              {
+                resultFields.map(({ name, sortable }) => (
+                  <th key={`th-${name}`}>
+                    {
+                      sortable ?
+                        <a
+                          className="crud--search-result-listing__sort-button"
+                          style={{ cursor: "pointer", whiteSpace: "nowrap" }}
+                          onClick={this.handleResort(name)}
+                        >
+                          { getModelMessage(i18n, `model.field.${name}`, name) }
+                          {
+                            sortField === name &&
+                            <Glyphicon
+                              className="crud--search-result-listing__sort-icon"
+                              glyph={`arrow-${sortOrder === 'asc' ? 'down' : 'up'}`}
+                            />
+                          }
+                        </a> :
+                        getModelMessage(i18n, `model.field.${name}`, name)
+                    }
+                  </th>
+                ))
+              }
 
               <th>&nbsp;</th>
             </tr>
           </thead>
           <tbody>
 
-            {instances.map((instance, index) =>
-              (<tr key={`tr-${JSON.stringify(instance)}`}>
-                {
-                  permissions.delete && (<td>
-                    <Checkbox
-                      checked={!!~selectedInstances.indexOf(instance)}
-                      onChange={this.handleToggleSelected(instance)}
+            {
+              instances.map((instance, index) => (
+                <tr key={`tr-${JSON.stringify(instance)}`}>
+                  {
+                    permissions.delete && (<td>
+                      <Checkbox
+                        checked={!!~selectedInstances.indexOf(instance)}
+                        onChange={this.handleToggleSelected(instance)}
+                      />
+                    </td>)
+                  }
+                  {
+                    resultFields.map(({ name, Component, textAlignment }) => (
+                      <td
+                        key={`td-${name}`}
+                        className={
+                          textAlignment === 'right' && 'text-right' ||
+                        textAlignment === 'center' && 'text-center' ||
+                        'text-left'
+                        }
+                      >
+                        {
+                          Component ?
+                            <Component name={name} instance={instance} /> :
+                            instance[name]
+                        }
+                      </td>
+                    ))
+                  }
+                  <td className="text-right">
+                    <SearchResultButtons
+                      model={this.props.model}
+                      onShow={this.handleShow(instance, index)}
+                      onEdit={this.handleEdit(instance, index)}
+                      onDelete={this.handleDelete(instance)}
                     />
-                  </td>)
-                }
-                {resultFields.map(({ name, Component, textAlignment }) =>
-                  (<td
-                    key={`td-${name}`}
-                    className={
-                      textAlignment === 'right' && 'text-right' ||
-                      textAlignment === 'center' && 'text-center' ||
-                      'text-left'
-                    }
-                  >
-                    {
-                      Component ?
-                        <Component name={name} instance={instance} /> :
-                        instance[name]
-                    }
-                  </td>)
-                )}
-
-                <td className="text-right">
-                  <SearchResultButtons
-                    model={this.props.model}
-                    instance={instance}
-                    index={index}
-                    onShow={this.handleShow}
-                    onEdit={this.handleEdit}
-                    onDelete={this.handleDelete}
-                  />
-                </td>
-              </tr>)
-            )}
-
+                  </td>
+                </tr>
+              ))
+            }
           </tbody>
         </Table>
       </div>

--- a/src/crudeditor-lib/lib.js
+++ b/src/crudeditor-lib/lib.js
@@ -84,20 +84,20 @@ export function fillDefaults(baseModelDefinition) {
     throw new Error('permissions.crudOperations must be defined in a crud model!');
   }
 
-  const ops = modelDefinition.permissions.crudOperations;
+  const allowedOps = modelDefinition.permissions.crudOperations;
 
   ['create', 'edit', 'delete', 'view'].forEach(operation => {
-    if (!ops.hasOwnProperty(operation)) {
-      ops[operation] = false
+    if (!allowedOps.hasOwnProperty(operation)) {
+      allowedOps[operation] = false
     }
   }
   );
 
   const getUi = {
-    ...(ops.view ? { [VIEW_SEARCH]: getSearchUi } : null),
-    ...(ops.create ? { [VIEW_CREATE]: getCreateUi } : null),
-    ...(ops.edit ? { [VIEW_EDIT]: getEditUi } : null),
-    ...(ops.view ? { [VIEW_SHOW]: getShowUi } : null)
+    ...(allowedOps.view ? { [VIEW_SEARCH]: getSearchUi } : null),
+    ...(allowedOps.create ? { [VIEW_CREATE]: getCreateUi } : null),
+    ...(allowedOps.edit ? { [VIEW_EDIT]: getEditUi } : null),
+    ...(allowedOps.view ? { [VIEW_SHOW]: getShowUi } : null)
   };
 
   Object.keys(getUi).forEach(viewName => {

--- a/src/crudeditor-lib/lib.js
+++ b/src/crudeditor-lib/lib.js
@@ -23,13 +23,6 @@ const getViewState = {
   [VIEW_ERROR]: getErrorViewState
 };
 
-const getUi = {
-  [VIEW_SEARCH]: getSearchUi,
-  [VIEW_CREATE]: getCreateUi,
-  [VIEW_EDIT]: getEditUi,
-  [VIEW_SHOW]: getShowUi
-};
-
 export const storeState2appState = (storeState, modelDefinition) => ({
   name: storeState.common.activeViewName,
   state: cloneDeep(getViewState[storeState.common.activeViewName](storeState, modelDefinition))
@@ -100,15 +93,15 @@ export function fillDefaults(baseModelDefinition) {
   }
   );
 
-  const canShowUi = {
-    [VIEW_CREATE]: ops.create,
-    [VIEW_EDIT]: ops.edit,
-    [VIEW_SEARCH]: ops.view,
-    [VIEW_SHOW]: ops.view
-  }
+  const getUi = {
+    ...(ops.view ? { [VIEW_SEARCH]: getSearchUi } : null),
+    ...(ops.create ? { [VIEW_CREATE]: getCreateUi } : null),
+    ...(ops.edit ? { [VIEW_EDIT]: getEditUi } : null),
+    ...(ops.view ? { [VIEW_SHOW]: getShowUi } : null)
+  };
 
   Object.keys(getUi).forEach(viewName => {
-    if (getUi[viewName] && canShowUi[viewName]) {
+    if (getUi[viewName]) {
       modelDefinition.ui[viewName] = getUi[viewName](modelDefinition);
     }
   })

--- a/src/crudeditor-lib/lib.js
+++ b/src/crudeditor-lib/lib.js
@@ -74,18 +74,30 @@ export function fillDefaults(baseModelDefinition) {
     modelDefinition.ui.instanceLabel = ({ _objectLabel }) => _objectLabel;
   }
 
-  if(!permissions || !permissions.crudOperations) { // TODO remove after we create a proper model validator
-    console.error('permissions.crudOperations must be defined in a crud model!');
+  if (!permissions || !permissions.crudOperations) { // TODO remove after we create a proper model validator
+    console.error('permissions.crudOperations must be defined in a crud schema!' + '\nExample: ' + JSON.stringify({
+      model: {},
+      api: {},
+      ui: {},
+      permissions: {
+        crudOperations: {
+          create: true,
+          edit: true,
+          delete: false,
+          view: true
+        }
+      }
+    }), null, 2);
     throw new Error('permissions.crudOperations must be defined in a crud model!');
   }
 
   const ops = modelDefinition.permissions.crudOperations;
 
   ['create', 'edit', 'delete', 'view'].forEach(operation => {
-      if (!ops.hasOwnProperty(operation)) {
-        ops[operation] = false
-      }
+    if (!ops.hasOwnProperty(operation)) {
+      ops[operation] = false
     }
+  }
   );
 
   const canShowUi = {

--- a/src/crudeditor-lib/rootReducer.js
+++ b/src/crudeditor-lib/rootReducer.js
@@ -15,15 +15,19 @@ import {
   VIEW_ERROR
 } from './common/constants';
 
-export default modelDefinition => combineReducers({
-  common: common(modelDefinition),
-  views: combineReducers(
-    (ops => ({
-      ...(ops.view ? { [VIEW_SEARCH]: search(modelDefinition) } : null),
-      ...(ops.create ? { [VIEW_CREATE]: create(modelDefinition) } : null),
-      ...(ops.edit ? { [VIEW_EDIT]: edit(modelDefinition) } : null),
-      ...(ops.view ? { [VIEW_SHOW]: show(modelDefinition) } : null),
-      [VIEW_ERROR]: error(modelDefinition)
-    }))(modelDefinition.permissions.crudOperations)
-  )
-});
+export default modelDefinition => {
+  const allowedOps = modelDefinition.permissions.crudOperations;
+
+  const viewReducers = {
+    ...(allowedOps.view ? { [VIEW_SEARCH]: search(modelDefinition) } : null),
+    ...(allowedOps.create ? { [VIEW_CREATE]: create(modelDefinition) } : null),
+    ...(allowedOps.edit ? { [VIEW_EDIT]: edit(modelDefinition) } : null),
+    ...(allowedOps.view ? { [VIEW_SHOW]: show(modelDefinition) } : null),
+    [VIEW_ERROR]: error(modelDefinition)
+  }
+
+  return combineReducers({
+    common: common(modelDefinition),
+    views: combineReducers(viewReducers)
+  });
+}

--- a/src/crudeditor-lib/rootReducer.js
+++ b/src/crudeditor-lib/rootReducer.js
@@ -17,11 +17,13 @@ import {
 
 export default modelDefinition => combineReducers({
   common: common(modelDefinition),
-  views: combineReducers({
-    [VIEW_SEARCH]: search(modelDefinition),
-    [VIEW_CREATE]: create(modelDefinition),
-    [VIEW_EDIT]: edit(modelDefinition),
-    [VIEW_SHOW]: show(modelDefinition),
-    [VIEW_ERROR]: error(modelDefinition)
-  })
+  views: combineReducers(
+    (ops => ({
+      ...(ops.view ? { [VIEW_SEARCH]: search(modelDefinition) } : null),
+      ...(ops.create ? { [VIEW_CREATE]: create(modelDefinition) } : null),
+      ...(ops.edit ? { [VIEW_EDIT]: edit(modelDefinition) } : null),
+      ...(ops.view ? { [VIEW_SHOW]: show(modelDefinition) } : null),
+      [VIEW_ERROR]: error(modelDefinition)
+    }))(modelDefinition.permissions.crudOperations)
+  )
 });

--- a/src/crudeditor-lib/rootSaga.js
+++ b/src/crudeditor-lib/rootSaga.js
@@ -22,14 +22,15 @@ import {
 
 
 export default function*(modelDefinition) {
-  const initializeViewSagas = (ops => ({
-    ...(ops.view ? { [VIEW_SEARCH]: searchViewScenario } : null),
-    ...(ops.create ? { [VIEW_CREATE]: createViewScenario } : null),
-    ...(ops.edit ? { [VIEW_EDIT]: editViewScenario } : null),
-    ...(ops.view ? { [VIEW_SHOW]: showViewScenario } : null),
+  const allowedOps = modelDefinition.permissions.crudOperations;
+
+  const initializeViewSagas = {
+    ...(allowedOps.view ? { [VIEW_SEARCH]: searchViewScenario } : null),
+    ...(allowedOps.create ? { [VIEW_CREATE]: createViewScenario } : null),
+    ...(allowedOps.edit ? { [VIEW_EDIT]: editViewScenario } : null),
+    ...(allowedOps.view ? { [VIEW_SHOW]: showViewScenario } : null),
     [VIEW_ERROR]: errorViewScenario
-  }))(modelDefinition.permissions.crudOperations)
-  ;
+  };
 
   let activeViewScenarioTask;
 

--- a/src/crudeditor-lib/rootSaga.js
+++ b/src/crudeditor-lib/rootSaga.js
@@ -22,13 +22,14 @@ import {
 
 
 export default function*(modelDefinition) {
-  const initializeViewSagas = {
-    [VIEW_SEARCH]: searchViewScenario,
-    [VIEW_CREATE]: createViewScenario,
-    [VIEW_EDIT]: editViewScenario,
-    [VIEW_SHOW]: showViewScenario,
+  const initializeViewSagas = (ops => ({
+    ...(ops.view ? { [VIEW_SEARCH]: searchViewScenario } : null),
+    ...(ops.create ? { [VIEW_CREATE]: createViewScenario } : null),
+    ...(ops.edit ? { [VIEW_EDIT]: editViewScenario } : null),
+    ...(ops.view ? { [VIEW_SHOW]: showViewScenario } : null),
     [VIEW_ERROR]: errorViewScenario
-  };
+  }))(modelDefinition.permissions.crudOperations)
+  ;
 
   let activeViewScenarioTask;
 

--- a/src/crudeditor-lib/rootSaga.js
+++ b/src/crudeditor-lib/rootSaga.js
@@ -20,15 +20,16 @@ import {
   VIEW_ERROR
 } from './common/constants';
 
-const initializeViewSagas = {
-  [VIEW_SEARCH]: searchViewScenario,
-  [VIEW_CREATE]: createViewScenario,
-  [VIEW_EDIT]: editViewScenario,
-  [VIEW_SHOW]: showViewScenario,
-  [VIEW_ERROR]: errorViewScenario
-};
 
 export default function*(modelDefinition) {
+  const initializeViewSagas = {
+    [VIEW_SEARCH]: searchViewScenario,
+    [VIEW_CREATE]: createViewScenario,
+    [VIEW_EDIT]: editViewScenario,
+    [VIEW_SHOW]: showViewScenario,
+    [VIEW_ERROR]: errorViewScenario
+  };
+
   let activeViewScenarioTask;
 
   /*

--- a/src/crudeditor-lib/views/create/selectors.js
+++ b/src/crudeditor-lib/views/create/selectors.js
@@ -25,8 +25,10 @@ export const
 
   getViewModelData = wrapper((storeState, {
     model: modelMeta,
-    ui: { Spinner }
+    ui: { Spinner },
+    permissions
   }) => ({
+    permissions,
     Spinner,
     activeEntries: storeState.activeTab || storeState.formLayout,
     activeTab: storeState.activeTab,

--- a/src/crudeditor-lib/views/edit/selectors.js
+++ b/src/crudeditor-lib/views/edit/selectors.js
@@ -30,8 +30,10 @@ export const
 
   getViewModelData = wrapper((storeState, {
     model: modelMeta,
-    ui: { Spinner }
+    ui: { Spinner },
+    permissions
   }) => ({
+    permissions,
     Spinner,
     activeEntries: storeState.activeTab || storeState.formLayout,
     activeTab: storeState.activeTab,

--- a/src/crudeditor-lib/views/search/selectors.js
+++ b/src/crudeditor-lib/views/search/selectors.js
@@ -74,8 +74,10 @@ export const
 
   getViewModelData = wrapper((storeState, {
     model: modelMeta,
-    ui: uiMeta
+    ui: uiMeta,
+    permissions
   }) => ({
+    permissions,
     Spinner: uiMeta.Spinner,
     entityName: modelMeta.name,
     fieldErrors: storeState.errors.fields,

--- a/src/crudeditor-lib/views/show/selectors.js
+++ b/src/crudeditor-lib/views/show/selectors.js
@@ -26,8 +26,10 @@ export const
 
   getViewModelData = wrapper((storeState, {
     model: modelMeta,
-    ui: { Spinner }
+    ui: { Spinner },
+    permissions
   }) => ({
+    permissions,
     Spinner,
     activeEntries: storeState.activeTab || storeState.formLayout,
     activeTab: storeState.activeTab,

--- a/src/demo/models/contracts/index.js
+++ b/src/demo/models/contracts/index.js
@@ -325,6 +325,14 @@ export default {
       return true;
     }
   },
+  permissions: {
+    crudOperations: {
+      create: false,
+      edit: true,
+      delete: true,
+      view: true
+    }
+  },
   api,
   ui: {
     search: _ => ({

--- a/src/demo/models/contracts/index.js
+++ b/src/demo/models/contracts/index.js
@@ -327,9 +327,9 @@ export default {
   },
   permissions: {
     crudOperations: {
-      create: false,
+      create: true,
       edit: true,
-      delete: true,
+      delete: false,
       view: true
     }
   },

--- a/src/demo/models/contracts/index.js
+++ b/src/demo/models/contracts/index.js
@@ -329,7 +329,7 @@ export default {
     crudOperations: {
       create: true,
       edit: true,
-      delete: false,
+      delete: true,
       view: true
     }
   },


### PR DESCRIPTION
Now consumer has to define `permissions` object in crud's schema along with `model`, `api` and `ui`.

Related issue: #48

Example: 
```
permissions: {
    crudOperations: {
      create: true,
      edit: true,
      delete: false,
      view: true
    }
  }
```
If `edit` is `true`, there will be `Edit` button on the Search Listing instead of both `Edit` and `Show`.

The same rule applies to all `Delete`-related elements, chopped out if `delete` is `false`.

`view` should be `true` in order to show Search view or Show view (in case the `edit` is disabled). 