### PR TITLE
Removed auditable fields definition from crud constants

### DIFF
--- a/src/crudeditor-lib/common/constants.js
+++ b/src/crudeditor-lib/common/constants.js
@@ -1,13 +1,6 @@
 const namespace = 'common';
 
 export const
-  AUDITABLE_FIELDS = [
-    'createdBy',
-    'changedBy',
-    'createdOn',
-    'changedOn'
-  ],
-
   ROLE_FIELD = 'field',
   ROLE_SECTION = 'section',
   ROLE_TAB = 'tab',

--- a/src/crudeditor-lib/views/lib.js
+++ b/src/crudeditor-lib/views/lib.js
@@ -84,7 +84,7 @@ const buildDefaultFormLayout = ({
     map(name => ({
       field: name,
       readOnly: viewName === VIEW_EDIT && (
-          fieldsMeta[name].unique // Logical Key fields are read-only in Edit View.
+        fieldsMeta[name].unique // Logical Key fields are read-only in Edit View.
       ),
       render: buildFieldRender({
         type: fieldsMeta[name].type

--- a/src/crudeditor-lib/views/lib.js
+++ b/src/crudeditor-lib/views/lib.js
@@ -79,17 +79,14 @@ export const buildFieldRender = ({
 const buildDefaultFormLayout = ({
   viewName,
   fieldsMeta
-}) => _ => [VIEW_SHOW, VIEW_EDIT].indexOf(viewName) > -1 ?
-  Object.keys(fieldsMeta).
-    map(name => ({
-      field: name,
-      readOnly: viewName === VIEW_EDIT &&
-        fieldsMeta[name].unique, // Logical Key fields are read-only in Edit View.
-      render: buildFieldRender({
-        type: fieldsMeta[name].type
-      })
-    })) :
-  [];
+}) => _ => Object.keys(fieldsMeta).map(name => ({
+  field: name,
+  readOnly: viewName === VIEW_EDIT &&
+    fieldsMeta[name].unique, // Logical Key fields are read-only in Edit View.
+  render: buildFieldRender({
+    type: fieldsMeta[name].type
+  })
+}));
 
 // █████████████████████████████████████████████████████████████████████████████████████████████████████████
 

--- a/src/crudeditor-lib/views/lib.js
+++ b/src/crudeditor-lib/views/lib.js
@@ -83,9 +83,8 @@ const buildDefaultFormLayout = ({
   Object.keys(fieldsMeta).
     map(name => ({
       field: name,
-      readOnly: viewName === VIEW_EDIT && (
-        fieldsMeta[name].unique // Logical Key fields are read-only in Edit View.
-      ),
+      readOnly: viewName === VIEW_EDIT &&
+        fieldsMeta[name].unique, // Logical Key fields are read-only in Edit View.
       render: buildFieldRender({
         type: fieldsMeta[name].type
       })

--- a/src/crudeditor-lib/views/lib.js
+++ b/src/crudeditor-lib/views/lib.js
@@ -6,7 +6,6 @@ import FieldNumber from '../../components/FieldNumber';
 import FieldDate from '../../components/FieldDate';
 
 import {
-  AUDITABLE_FIELDS,
   DEFAULT_TAB_COLUMNS,
   VIEW_EDIT,
   VIEW_SHOW
@@ -80,18 +79,18 @@ export const buildFieldRender = ({
 const buildDefaultFormLayout = ({
   viewName,
   fieldsMeta
-}) => _ => Object.keys(fieldsMeta).
-  filter(name => [VIEW_SHOW, VIEW_EDIT].indexOf(viewName) > -1 || AUDITABLE_FIELDS.indexOf(name) === -1).
-  map(name => ({
-    field: name,
-    readOnly: viewName === VIEW_EDIT && (
-      AUDITABLE_FIELDS.indexOf(name) > -1 || // Audiatable fields are read-only in Edit View.
-        fieldsMeta[name].unique // Logical Key fields are read-only in Edit View.
-    ),
-    render: buildFieldRender({
-      type: fieldsMeta[name].type
-    })
-  }));
+}) => _ => [VIEW_SHOW, VIEW_EDIT].indexOf(viewName) > -1 ?
+  Object.keys(fieldsMeta).
+    map(name => ({
+      field: name,
+      readOnly: viewName === VIEW_EDIT && (
+          fieldsMeta[name].unique // Logical Key fields are read-only in Edit View.
+      ),
+      render: buildFieldRender({
+        type: fieldsMeta[name].type
+      })
+    })) :
+  [];
 
 // █████████████████████████████████████████████████████████████████████████████████████████████████████████
 

--- a/src/crudeditor-lib/views/search/index.js
+++ b/src/crudeditor-lib/views/search/index.js
@@ -2,7 +2,6 @@ import cloneDeep from 'lodash/cloneDeep';
 
 import { RANGE_FIELD_TYPES } from './constants';
 import { buildFieldRender } from '../lib';
-import { AUDITABLE_FIELDS } from '../../common/constants';
 
 export { getViewState } from './selectors';
 
@@ -19,7 +18,6 @@ export const getUi = modelDefinition => {
 
   if (!searchMeta.searchableFields) {
     searchMeta.searchableFields = Object.keys(fieldsMeta).
-      filter(name => AUDITABLE_FIELDS.indexOf(name) === -1).
       map(name => ({ name }));
   }
 


### PR DESCRIPTION
This is enough if you define a field as `readOnly: true` in a formLayout. 

#79