### PR TITLE
Updated packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,8 +50,8 @@
   "devDependencies": {
     "@opuscapita/i18n": "1.1.0",
     "@opuscapita/npm-scripts": "2.0.1-beta.1",
-    "@opuscapita/react-navigation": "0.0.20",
-    "@opuscapita/react-reference-select": "1.0.4",
+    "@opuscapita/react-navigation": "0.0.38",
+    "@opuscapita/react-reference-select": "2.0.1",
     "@opuscapita/react-showroom-client": "1.3.0-beta.4",
     "@opuscapita/react-showroom-server": "1.3.0",
     "@opuscapita/styles": "1.0.0",

--- a/src/crudeditor-lib/views/lib.spec.js
+++ b/src/crudeditor-lib/views/lib.spec.js
@@ -330,7 +330,7 @@ describe('Crudeditor-lib / views / lib', () => {
     storeState.formLayout[1].tab = "additional";
 
     it('should return a tab from formLayout', () => {
-      const result = getTab(storeState, 'additional');
+      const result = getTab(storeState.formLayout, 'additional');
       assert.deepEqual(
         result,
         storeState.formLayout[1]
@@ -338,7 +338,7 @@ describe('Crudeditor-lib / views / lib', () => {
     });
 
     it('should return the first tab if name is not specified', () => {
-      const result = getTab(storeState);
+      const result = getTab(storeState.formLayout);
       assert.deepEqual(
         result,
         storeState.formLayout[0]
@@ -346,7 +346,7 @@ describe('Crudeditor-lib / views / lib', () => {
     });
 
     it('should return the first tab if name is unknown', () => {
-      const result = getTab(storeState, 'kwhe8923o23y8[023');
+      const result = getTab(storeState.formLayout, 'kwhe8923o23y8[023');
       assert.deepEqual(
         result,
         storeState.formLayout[0]


### PR DESCRIPTION
React-reference-select is ok, react-navigation (used in client with navigation) still breaks on React 16.x