### PR TITLE
Hint & tooltip for fields

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: opuscapita/ci-node8:latest
+      - image: circleci/node:7
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,11 +5,11 @@ jobs:
       - image: circleci/node:7
     steps:
       - checkout
-      # - restore_cache:
-      #     keys:
-      #     - v1-dependencies-{{ checksum "package.json" }}
-      #     # fallback to using the latest cache if no exact match is found
-      #     - v1-dependencies-
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "package.json" }}
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
 
       - run:
           name: install-dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:8
+      - image: circleci/node:7
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,11 +5,11 @@ jobs:
       - image: circleci/node:7
     steps:
       - checkout
-      - restore_cache:
-          keys:
-          - v1-dependencies-{{ checksum "package.json" }}
-          # fallback to using the latest cache if no exact match is found
-          - v1-dependencies-
+      # - restore_cache:
+      #     keys:
+      #     - v1-dependencies-{{ checksum "package.json" }}
+      #     # fallback to using the latest cache if no exact match is found
+      #     - v1-dependencies-
 
       - run:
           name: install-dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:7
+      - image: opuscapita/ci-node8:latest
     steps:
       - checkout
       - restore_cache:

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint": "node ./node_modules/eslint/bin/eslint.js ./src --config ./config/.eslintrc",
     "lint-fix": "node ./node_modules/eslint/bin/eslint.js ./src --config ./config/.eslintrc --fix",
     "lint-tab": "node ./node_modules/eslint/bin/eslint.js ./src --config ./config/.eslintrc --rule '\"indent\": [2, \"tab\", { \"SwitchCase\": 1, \"VariableDeclarator\": 1 }]' --rule '\"react/jsx-indent-props\": [2, \"tab\"]'",
-    "test": "rimraf ./.nyc_output ./coverage && cross-env nyc mocha --recursive src/**/*.spec.js --require ignore-styles",
+    "test": "rimraf ./.nyc_output ./coverage && cross-env nyc mocha --recursive src/**/**/*.spec.js --require ignore-styles",
     "start": "cross-env NODE_ENV=development webpack-dev-server --config config/webpack.config.babel.js",
     "build": "cross-env NODE_ENV=development webpack --config config/webpack.config.babel.js",
     "start-showroom": "cross-env NODE_ENV=development showroom-scan ./src && webpack-dev-server --config config/webpack.config.showroom.js",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint": "node ./node_modules/eslint/bin/eslint.js ./src --config ./config/.eslintrc",
     "lint-fix": "node ./node_modules/eslint/bin/eslint.js ./src --config ./config/.eslintrc --fix",
     "lint-tab": "node ./node_modules/eslint/bin/eslint.js ./src --config ./config/.eslintrc --rule '\"indent\": [2, \"tab\", { \"SwitchCase\": 1, \"VariableDeclarator\": 1 }]' --rule '\"react/jsx-indent-props\": [2, \"tab\"]'",
-    "test": "rimraf ./.nyc_output ./coverage && cross-env nyc mocha --recursive src/**/**/**/**/**/**/**/**/**/**/*.spec.js --require ignore-styles",
+    "test": "rimraf ./.nyc_output ./coverage && cross-env nyc mocha --recursive \"src/**/*.spec.js\" --require ignore-styles",
     "start": "cross-env NODE_ENV=development webpack-dev-server --config config/webpack.config.babel.js",
     "build": "cross-env NODE_ENV=development webpack --config config/webpack.config.babel.js",
     "start-showroom": "cross-env NODE_ENV=development showroom-scan ./src && webpack-dev-server --config config/webpack.config.showroom.js",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint": "node ./node_modules/eslint/bin/eslint.js ./src --config ./config/.eslintrc",
     "lint-fix": "node ./node_modules/eslint/bin/eslint.js ./src --config ./config/.eslintrc --fix",
     "lint-tab": "node ./node_modules/eslint/bin/eslint.js ./src --config ./config/.eslintrc --rule '\"indent\": [2, \"tab\", { \"SwitchCase\": 1, \"VariableDeclarator\": 1 }]' --rule '\"react/jsx-indent-props\": [2, \"tab\"]'",
-    "test": "rimraf ./.nyc_output ./coverage && cross-env nyc mocha --recursive src/**/**/*.spec.js --require ignore-styles",
+    "test": "rimraf ./.nyc_output ./coverage && cross-env nyc mocha --recursive src/**/**/**/**/**/**/**/**/**/**/*.spec.js --require ignore-styles",
     "start": "cross-env NODE_ENV=development webpack-dev-server --config config/webpack.config.babel.js",
     "build": "cross-env NODE_ENV=development webpack --config config/webpack.config.babel.js",
     "start-showroom": "cross-env NODE_ENV=development showroom-scan ./src && webpack-dev-server --config config/webpack.config.showroom.js",

--- a/src/components/EditField/index.js
+++ b/src/components/EditField/index.js
@@ -7,10 +7,11 @@ import {
   Glyphicon,
   FormControl,
   OverlayTrigger,
-  Popover
+  Popover,
+  Label
 } from 'react-bootstrap';
-import { getModelMessage } from '../lib'
 import FieldErrorLabel from '../FieldErrors/FieldErrorLabel';
+import './styles.less';
 
 // XXX: Component, not PureComponent must be used to catch instance's field value change.
 export default class EditField extends Component {
@@ -85,7 +86,9 @@ export default class EditField extends Component {
 
     const labelColumns = columns <= 4 ? 2 * columns : 6;
 
-    const fieldLabelMessage = getModelMessage(this.context.i18n, `model.field.${fieldName}.label`, fieldName);
+    const fieldLabel = fieldsMeta[fieldName].label;
+    const fieldTooltip = fieldsMeta[fieldName].tooltip;
+    const fieldHint = fieldsMeta[fieldName].hint;
 
     // TODO decide between top/bottom popover position according to screen boundaries
 
@@ -93,35 +96,48 @@ export default class EditField extends Component {
       <FormGroup controlId={fieldName} validationState={!readOnly && toggledFieldErrors[fieldName] ? 'error' : null}>
         <Col componentClass={ControlLabel} sm={labelColumns}>
           {
-            fieldLabelMessage + (required ? '*' : '')
+            fieldLabel + (required ? '*' : '')
           }
         </Col>
-        <Col sm={12 - labelColumns}>
+        <Col sm={12 - labelColumns} style={{ display: 'flex' }}>
           <Col sm={1}>
-            <FormControl.Static className='text-right' style={{ cursor: 'pointer', verticalAlign: 'middle' }}>
-              <OverlayTrigger
-                trigger="click"
-                rootClose={true}
-                placement="top"
-                overlay={
-                  <Popover
-                    id={`${fieldName}-tooltip`}
-                    title={<label>{fieldLabelMessage}</label>}
+            {
+              fieldTooltip && (
+                <FormControl.Static className='text-right' style={{ cursor: 'pointer', verticalAlign: 'middle' }}>
+                  <OverlayTrigger
+                    trigger="click"
+                    rootClose={true}
+                    placement="top"
+                    overlay={
+                      <Popover
+                        id={`${fieldName}-tooltip`}
+                        title={<label>{fieldLabel}</label>}
+                      >
+                        <small className="text-muted">
+                          { fieldTooltip }
+                        </small>
+                      </Popover>
+                    }
                   >
-                    <small class="text-muted">
-                      Internal human readable name for this Supplier. E.g. 'Bosch Frankfurt HQ'.
-                      ID could be composed of some cryptic alphanumeric characters. e.g. <i>BO13456</i>.
-                    </small>
-                  </Popover>
-                }
-              >
-                <Glyphicon glyph="info-sign" className='text-muted'/>
-              </OverlayTrigger>
-            </FormControl.Static>
+                    <Glyphicon glyph="info-sign" className='text-muted'/>
+                  </OverlayTrigger>
+                </FormControl.Static>
+              )
+            }
           </Col>
           <Col sm={11}>
             <FieldInput {...fieldInputProps} />
-            <FieldErrorLabel errors={!readOnly && toggledFieldErrors[fieldName] || []} fieldName={fieldName}/>
+            {
+              !!(!readOnly && toggledFieldErrors[fieldName]) ?
+                (
+                  <FieldErrorLabel errors={toggledFieldErrors[fieldName]} fieldName={fieldName}/>
+                ) :
+                (
+                  <Label className="hint">
+                    <small className="text-muted">{ fieldHint || '\u00A0' }</small>
+                  </Label>
+                )
+            }
           </Col>
         </Col>
       </FormGroup>

--- a/src/components/EditField/index.js
+++ b/src/components/EditField/index.js
@@ -101,7 +101,7 @@ export default class EditField extends Component {
             <FormControl.Static className='text-right' style={{ cursor: 'pointer', verticalAlign: 'middle' }}>
               <OverlayTrigger
                 trigger="click"
-                rootClose
+                rootClose={true}
                 placement="top"
                 overlay={
                   <Popover

--- a/src/components/EditField/index.js
+++ b/src/components/EditField/index.js
@@ -1,6 +1,14 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { FormGroup, Col, ControlLabel } from 'react-bootstrap';
+import {
+  FormGroup,
+  Col,
+  ControlLabel,
+  Glyphicon,
+  FormControl,
+  OverlayTrigger,
+  Popover
+} from 'react-bootstrap';
 import { getModelMessage } from '../lib'
 import FieldErrorLabel from '../FieldErrors/FieldErrorLabel';
 
@@ -77,16 +85,44 @@ export default class EditField extends Component {
 
     const labelColumns = columns <= 4 ? 2 * columns : 6;
 
+    const fieldLabelMessage = getModelMessage(this.context.i18n, `model.field.${fieldName}.label`, fieldName);
+
+    // TODO decide between top/bottom popover position according to screen boundaries
+
     return (
       <FormGroup controlId={fieldName} validationState={!readOnly && toggledFieldErrors[fieldName] ? 'error' : null}>
         <Col componentClass={ControlLabel} sm={labelColumns}>
           {
-            getModelMessage(this.context.i18n, `model.field.${fieldName}.label`, fieldName) + (required ? '*' : '')
+            fieldLabelMessage + (required ? '*' : '')
           }
         </Col>
         <Col sm={12 - labelColumns}>
-          <FieldInput {...fieldInputProps} />
-          <FieldErrorLabel errors={!readOnly && toggledFieldErrors[fieldName] || []} fieldName={fieldName}/>
+          <Col sm={1}>
+            <FormControl.Static className='text-right' style={{ cursor: 'pointer', verticalAlign: 'middle' }}>
+              <OverlayTrigger
+                trigger="click"
+                rootClose
+                placement="top"
+                overlay={
+                  <Popover
+                    id={`${fieldName}-tooltip`}
+                    title={<label>{fieldLabelMessage}</label>}
+                  >
+                    <small class="text-muted">
+                      Internal human readable name for this Supplier. E.g. 'Bosch Frankfurt HQ'.
+                      ID could be composed of some cryptic alphanumeric characters. e.g. <i>BO13456</i>.
+                    </small>
+                  </Popover>
+                }
+              >
+                <Glyphicon glyph="info-sign" className='text-muted'/>
+              </OverlayTrigger>
+            </FormControl.Static>
+          </Col>
+          <Col sm={11}>
+            <FieldInput {...fieldInputProps} />
+            <FieldErrorLabel errors={!readOnly && toggledFieldErrors[fieldName] || []} fieldName={fieldName}/>
+          </Col>
         </Col>
       </FormGroup>
     );

--- a/src/components/EditField/styles.less
+++ b/src/components/EditField/styles.less
@@ -1,0 +1,5 @@
+.hint {
+  font-weight: normal;
+  font-size: 100%;
+  border: none !important
+}

--- a/src/components/EditHeading/index.js
+++ b/src/components/EditHeading/index.js
@@ -2,7 +2,7 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import isEqual from 'lodash/isEqual';
 
-import { getModelMessage } from '../lib';
+import { getModelMessage } from '../../crudeditor-lib/lib';
 import { VIEW_CREATE } from '../../crudeditor-lib/common/constants';
 import ConfirmUnsavedChanges from '../ConfirmDialog/ConfirmUnsavedChanges';
 

--- a/src/components/EditSection/index.js
+++ b/src/components/EditSection/index.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Collapse } from 'react-bootstrap';
-import { getModelMessage } from '../lib';
+import { getModelMessage } from '../../crudeditor-lib/lib';
 import './styles.less';
 
 export default class EditSelection extends Component {

--- a/src/components/EditTab/index.js
+++ b/src/components/EditTab/index.js
@@ -1,7 +1,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import isEqual from 'lodash/isEqual';
-import { getModelMessage } from '../lib';
+import { getModelMessage } from '../../crudeditor-lib/lib';
 import ConfirmDialog from '../ConfirmDialog';
 import ConfirmUnsavedChanges from '../ConfirmDialog/ConfirmUnsavedChanges';
 import FormGrid from '../FormGrid';

--- a/src/components/FieldErrors/FieldErrorLabel.js
+++ b/src/components/FieldErrors/FieldErrorLabel.js
@@ -16,7 +16,7 @@ export default class FieldErrorLabel extends PureComponent {
     errors: PropTypes.arrayOf(PropTypes.shape({
       id: PropTypes.string,
       code: PropTypes.number,
-      message: PropTypes.string,
+      message: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
       payload: PropTypes.string
     })),
     fieldName: PropTypes.string.isRequired
@@ -55,15 +55,15 @@ export default class FieldErrorLabel extends PureComponent {
   render() {
     const { errors } = this.props;
 
+    const hasErrors = !!errors.length;
+
     return (
-      <div style={{ display: "block" }}>
-        <div style={{ opacity: errors.length ? '1' : '0' }}>
-          <Fade in={!!errors.length}>
-            <Label bsStyle="danger">
-              {errors.length ? this.getErrorMessage(errors[0]) : ' '}
-            </Label>
-          </Fade>
-        </div>
+      <div style={{ display: "block", opacity: hasErrors ? '1' : '0' }}>
+        <Fade in={hasErrors}>
+          <Label bsStyle="danger">
+            {hasErrors ? this.getErrorMessage(errors[0]) : ' '}
+          </Label>
+        </Fade>
       </div>
     )
   }

--- a/src/components/FieldErrors/WithFieldErrorsHOC.js
+++ b/src/components/FieldErrors/WithFieldErrorsHOC.js
@@ -14,7 +14,7 @@ export default WrappedComponent => class WithFieldErrors extends PureComponent {
         fieldErrors: PropTypes.objectOf(PropTypes.arrayOf(PropTypes.shape({
           id: PropTypes.string,
           code: PropTypes.number,
-          message: PropTypes.string
+          message: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
         })))
       })
     }).isRequired

--- a/src/components/SearchForm/index.js
+++ b/src/components/SearchForm/index.js
@@ -2,8 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import isEqual from 'lodash/isEqual';
 import { Button, Form, FormGroup, ControlLabel } from 'react-bootstrap';
-
-import { getModelMessage } from '../lib';
 import FieldErrorLabel from '../FieldErrors/FieldErrorLabel';
 import WithFieldErrors from '../FieldErrors/WithFieldErrorsHOC';
 import './SearchForm.less';
@@ -64,20 +62,22 @@ class SearchForm extends React.Component {
       }
     } = this.props;
 
+    console.log('search form', this.props.model.data)
+
     const { i18n } = this.context;
 
     return (
       <Form horizontal={true} onSubmit={this.handleSubmit} className="clearfix crud--search-form">
         <div className="crud--search-form__controls">
           {
-            searchableFields.map(({ name, component: Component, valuePropName }) => (
+            searchableFields.map(({ name, component: Component, valuePropName, label }) => (
               <FormGroup
                 key={`form-group-${name}`}
                 controlId={`fg-${name}`}
                 validationState={this.fieldErrors(name).length ? 'error' : null}
                 className="crud--search-form__form-group"
               >
-                <ControlLabel>{getModelMessage(i18n, `model.field.${name}.label`, name)}</ControlLabel>
+                <ControlLabel>{label}</ControlLabel>
                 <Component
                   {...{ [valuePropName]: formattedFilter[name] }}
                   onChange={this.handleFormFilterUpdate(name)}

--- a/src/components/SearchForm/index.js
+++ b/src/components/SearchForm/index.js
@@ -62,8 +62,6 @@ class SearchForm extends React.Component {
       }
     } = this.props;
 
-    console.log('search form', this.props.model.data)
-
     const { i18n } = this.context;
 
     return (

--- a/src/components/SearchMain/index.js
+++ b/src/components/SearchMain/index.js
@@ -8,7 +8,7 @@ import {
 } from 'react-bootstrap';
 import Form from '../SearchForm';
 import Result from '../SearchResult';
-import { getModelMessage } from '../lib';
+import { getModelMessage } from '../../crudeditor-lib/lib';
 import './SearchMain.less';
 
 export default class SearchMain extends PureComponent {

--- a/src/components/SearchResultListing/SearchResultButtons.js
+++ b/src/components/SearchResultListing/SearchResultButtons.js
@@ -8,7 +8,7 @@ import {
   MenuItem
 } from 'react-bootstrap';
 import ConfirmDialog from '../ConfirmDialog';
-import { getModelMessage } from '../lib';
+import { getModelMessage } from '../../crudeditor-lib/lib';
 
 export default class SearchResultButtons extends PureComponent {
   static propTypes = {

--- a/src/components/SearchResultListing/index.js
+++ b/src/components/SearchResultListing/index.js
@@ -2,7 +2,6 @@ import React, { PureComponent } from 'react';
 import { findDOMNode } from 'react-dom';
 import PropTypes from 'prop-types';
 import { Table, Glyphicon, Checkbox } from 'react-bootstrap';
-import { getModelMessage } from '../lib';
 import SearchResultButtons from './SearchResultButtons';
 import './SearchResultListing.less';
 
@@ -117,7 +116,7 @@ class SearchResultListing extends PureComponent {
               }
 
               {
-                resultFields.map(({ name, sortable }) => (
+                resultFields.map(({ name, sortable, label }) => (
                   <th key={`th-${name}`}>
                     {
                       sortable ?
@@ -126,7 +125,7 @@ class SearchResultListing extends PureComponent {
                           style={{ cursor: "pointer", whiteSpace: "nowrap" }}
                           onClick={this.handleResort(name)}
                         >
-                          { getModelMessage(i18n, `model.field.${name}.label`, name) }
+                          {`${label}`}
                           {
                             sortField === name &&
                             <Glyphicon
@@ -135,7 +134,7 @@ class SearchResultListing extends PureComponent {
                             />
                           }
                         </a> :
-                        getModelMessage(i18n, `model.field.${name}.label`, name)
+                        label
                     }
                   </th>
                 ))

--- a/src/components/lib.js
+++ b/src/components/lib.js
@@ -1,12 +1,3 @@
-export const getModelMessage = (i18n, key, defaultKey) => {
-  const message = i18n.getMessage(key);
-
-  // if @opuscapita/i18n doesn't find a message by key, it returns the key itself
-  return message.slice(-key.length) === key && defaultKey ?
-    defaultKey.charAt(0).toUpperCase() + defaultKey.slice(1).replace(/[^A-Z](?=[A-Z])/g, '$&\u00A0') :
-    message;
-}
-
 export const isDef = v => v !== null && v !== undefined;
 
 export const noop = _ => {};

--- a/src/components/lib.spec.js
+++ b/src/components/lib.spec.js
@@ -1,32 +1,7 @@
-import { I18nManager } from '@opuscapita/i18n';
 import { expect } from 'chai';
-import { getModelMessage, isDef } from './lib';
-
-const i18n = new I18nManager();
-
-const bundle = {
-  en: {
-    "model.field.contractId": "one",
-    "crud.prefix.model.field.status": "two"
-  }
-}
-
-i18n.register('component', bundle);
+import { isDef } from './lib';
 
 describe("components lib.js", _ => {
-  describe("getModelMessage", _ => {
-    it("should return translation for clear key", () => {
-      const key = "model.field.contractId";
-      const message = getModelMessage(i18n, key);
-      expect(message).to.equal(bundle.en[key]); // eslint-disable-line no-unused-expressions
-    });
-
-    it("should return translation for prefixed key", () => {
-      const message = getModelMessage(i18n, "model.field.status", "status");
-      expect(message).to.equal("Status"); // eslint-disable-line no-unused-expressions
-    });
-  });
-
   describe("isDef", _ => {
     it("should return false for null", () => {
       const result = isDef(null);

--- a/src/crudeditor-lib/index.js
+++ b/src/crudeditor-lib/index.js
@@ -24,7 +24,8 @@ import {
 import {
   storeState2appState,
   fillDefaults,
-  getPrefixedTranslations
+  getPrefixedTranslations,
+  addMessagesToFields
 } from './lib';
 
 import {
@@ -164,6 +165,11 @@ export default baseModelDefinition => {
       this.adjustedContext = {
         i18n: adjustedI18n
       };
+
+      modelDefinition.model.fields = addMessagesToFields({
+        i18n: adjustedI18n,
+        fields: modelDefinition.model.fields
+      });
 
       const sagaMiddleware = createSagaMiddleware();
 

--- a/src/crudeditor-lib/lib.js
+++ b/src/crudeditor-lib/lib.js
@@ -212,3 +212,31 @@ export function fillDefaults(baseModelDefinition) {
 
   return modelDefinition;
 }
+
+export const titleCase = str => str.charAt(0).toUpperCase() + str.slice(1).replace(/[^A-Z](?=[A-Z])/g, '$&\u00A0');
+
+export const getModelMessage = (i18n, key, defaultKey) => {
+  const message = i18n.getMessage(key);
+
+  // if @opuscapita/i18n doesn't find a message by key, it returns the key itself
+  return message.slice(-key.length) === key && defaultKey ?
+    titleCase(defaultKey) :
+    message;
+}
+
+const maybeGetModelMessage = (i18n, key) => {
+  const message = i18n.getMessage(key);
+  return message.slice(-key.length) === key ? null : message
+}
+
+export const addMessagesToFields = ({ i18n, fields }) => Object.keys(fields).reduce(
+  (acc, fieldName) => ({
+    ...acc,
+    [fieldName]: {
+      ...fields[fieldName],
+      label: getModelMessage(i18n, `model.field.${fieldName}.label`, fieldName),
+      ...((tooltip => tooltip && { tooltip })(maybeGetModelMessage(i18n, `model.field.${fieldName}.tooltip`))),
+      ...((hint => hint && { hint })(maybeGetModelMessage(i18n, `model.field.${fieldName}.hint`)))
+    }
+  }), {}
+)

--- a/src/crudeditor-lib/lib.spec.js
+++ b/src/crudeditor-lib/lib.spec.js
@@ -1,1 +1,79 @@
-// TODO
+import { expect } from 'chai';
+import { I18nManager } from '@opuscapita/i18n';
+import {
+  getModelMessage,
+  addMessagesToFields,
+  titleCase
+} from './lib';
+
+const i18n = new I18nManager();
+
+const messages = {
+  en: {
+    'model.field.one.label': 'one label',
+    'model.field.one.tooltip': 'one tooltip',
+    'model.field.one.hint': 'one hint',
+
+    'model.field.two.label': 'two label',
+    'model.field.two.tooltip': 'two tooltip',
+
+    'model.field.three.label': 'three label',
+    'model.field.three.hint': 'three hint',
+
+    'model.field.four.label': 'four label',
+  }
+};
+
+i18n.register('Test', messages);
+
+describe('crudeditor-lib / lib', () => {
+  describe('titleCase', () => {
+    it('should create a Title Case message from camelCase id', () => {
+      expect(titleCase('word')).to.equal('Word');
+      expect(titleCase('someId')).to.equal('Some\u00A0Id');
+      expect(titleCase('someFieldName')).to.equal('Some\u00A0Field\u00A0Name');
+    });
+  });
+
+  describe("getModelMessage", _ => {
+    it("should return translation for clear key", () => {
+      const key = "model.field.one.label";
+      const message = getModelMessage(i18n, key);
+      expect(message).to.equal(messages.en[key]); // eslint-disable-line no-unused-expressions
+    });
+
+    it("should return translation for prefixed key", () => {
+      const message = getModelMessage(i18n, "model.field.status.label", "status");
+      expect(message).to.equal("Status"); // eslint-disable-line no-unused-expressions
+    });
+  });
+
+  describe('addMessagesToFields', () => {
+    const fields = {
+      one: { type: 'something' },
+      two: { type: 'something' },
+      three: { type: 'something' },
+      four: { type: 'something' },
+      five: { type: 'something' },
+    }
+
+    const newFields = addMessagesToFields({ fields, i18n });
+
+    it('should add label, tooltip and hint to each field if exists', () => {
+      expect(newFields).to.be.an('object');
+      expect(newFields.one).to.have.all.keys('type', 'label', 'tooltip', 'hint');
+      expect(newFields.two).to.have.all.keys('type', 'label', 'tooltip').but.not.key('hint');
+      expect(newFields.three).to.have.all.keys('type', 'label', 'hint').but.not.key('tooltip');
+      expect(newFields.four).to.have.all.keys('type', 'label').but.not.all.keys('tooltip', 'hint');
+      expect(newFields.five).to.have.all.keys('type', 'label').but.not.all.keys('tooltip', 'hint');
+    });
+
+    it('should handle messages properly', () => {
+      const msgs = messages.en;
+      expect(newFields.one.label).to.equal(msgs['model.field.one.label']);
+      expect(newFields.one.tooltip).to.equal(msgs['model.field.one.tooltip']);
+      expect(newFields.one.hint).to.equal(msgs['model.field.one.hint']);
+      expect(newFields.five.label).to.equal(titleCase('five'));
+    })
+  });
+})

--- a/src/crudeditor-lib/views/lib.js
+++ b/src/crudeditor-lib/views/lib.js
@@ -350,7 +350,7 @@ export const buildFormLayout = ({ customBuilder, viewName, fieldsMeta }) => cust
     section: sectionLayout,
     field: buildFieldLayout(viewName, fieldsMeta)
   }) :
-  buildDefaultFormLayout({ viewName, fieldsMeta });
+  buildDefaultFormLayout({ viewName, fieldsMeta }); //
 
 // █████████████████████████████████████████████████████████████████████████████████████████████████████████
 

--- a/src/crudeditor-lib/views/lib.js
+++ b/src/crudeditor-lib/views/lib.js
@@ -350,7 +350,7 @@ export const buildFormLayout = ({ customBuilder, viewName, fieldsMeta }) => cust
     section: sectionLayout,
     field: buildFieldLayout(viewName, fieldsMeta)
   }) :
-  buildDefaultFormLayout({ viewName, fieldsMeta }); //
+  buildDefaultFormLayout({ viewName, fieldsMeta });
 
 // █████████████████████████████████████████████████████████████████████████████████████████████████████████
 

--- a/src/crudeditor-lib/views/search/selectors.js
+++ b/src/crudeditor-lib/views/search/selectors.js
@@ -101,7 +101,11 @@ export const
       max: storeState.pageParams.max,
       offset: storeState.pageParams.offset
     },
-    resultFields,
+    resultFields: resultFields.map(({ name, ...rest }) => ({
+      name,
+      ...rest,
+      label: modelMeta.fields[name].label
+    })),
     resultFilter: storeState.resultFilter,
     resultInstances: storeState.resultInstances,
     searchableFields: searchableFields.map(({
@@ -115,7 +119,8 @@ export const
     }) => ({
       name,
       component,
-      valuePropName
+      valuePropName,
+      label: modelMeta.fields[name].label
     })),
     selectedInstances: storeState.selectedInstances,
     sortParams: {

--- a/src/demo/models/contracts/components/ContractReferenceSearch/index.js
+++ b/src/demo/models/contracts/components/ContractReferenceSearch/index.js
@@ -9,7 +9,7 @@ import {
 } from '@opuscapita/react-reference-select';
 import translations from './i18n';
 import ReferenceSearchService from './ReferenceSearchService';
-import { getModelMessage } from '../../../../../components/lib';
+import { getModelMessage } from '../../../../../crudeditor-lib/lib';
 import './styles.less';
 
 const SERVICE_NAME = 'ContractReferenceSearch';

--- a/src/demo/models/contracts/i18n/en.js
+++ b/src/demo/models/contracts/i18n/en.js
@@ -9,8 +9,10 @@ export default {
   "model.field.contractBoilerplates.label": "Contract Boilerplates",
   "model.field.hierarchyCode.label": "Hierarchy Code",
   "model.field.termsOfPaymentId.label": "Terms Of Payment Id",
-  "model.field.description.label": "Description",
 
+  "model.field.description.label": "Description",
+  "model.field.description.tooltip": "Can be any arbitrary text of your choice.",
+  "model.field.description.hint": "A good description should be descriptive.",
   "model.field.description.error.forbiddenWord": "Description may not contain `{forbiddenWord}`",
 
   "model.field.termsOfDeliveryId.label": "Terms Of Delivery Id",
@@ -25,6 +27,9 @@ export default {
   "model.field.changedBy.label": "Changed By",
   "model.field.usages.label": "usages",
   "model.field.currencyId.label": "currencyId",
+
+  "model.field.contractId.tooltip": "Unique contract identifier.",
+  "model.field.contractId.hint": "Unique contract identifier.",
 
   "model.label.createChild": "Create child"
 }


### PR DESCRIPTION
#202 

Tooltip is a popover shown when you click `i` sign. Hint is a grey message below input.

Tooltip and/or hint are visible if there is a translation message defined by keys 

`model.field.FIELD_NAME.tooltip`
`model.field.FIELD_NAME.hint`

Internal changes: translated labels, hints and tooltips are queued from i18n only once when the crud is created. Previously i18n was queued on every field render.

TODO/TBD: dynamic popover positioning? Currently popover shows always on top of the `i` sign, regardless the viewport edges.