### PR TITLE
Removed some react-bootstrap components

### DIFF
--- a/config/webpack.config.build.js
+++ b/config/webpack.config.build.js
@@ -13,9 +13,9 @@ module.exports = merge(common, {
     library: `ReactCrudEditor`,
     libraryTarget: 'umd'
   },
-  externals: [
-    nodeExternals({
-      modulesFromFile: true
-    })
-  ]
+  // externals: [
+  //   nodeExternals({
+  //     modulesFromFile: true
+  //   })
+  // ]
 });

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "enzyme": "3.3.0",
     "enzyme-adapter-react-15": "1.0.5",
     "eslint": "4.19.1",
-    "eslint-config-opuscapita": "2.0.0",
+    "eslint-config-opuscapita": "2.0.1",
     "eslint-plugin-react": "7.7.0",
     "file-loader": "1.1.11",
     "html-webpack-plugin": "3.2.0",

--- a/src/components/ConfirmDialog/index.js
+++ b/src/components/ConfirmDialog/index.js
@@ -2,7 +2,6 @@ import React, { PureComponent, Children } from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import Modal from 'react-bootstrap/lib/Modal';
-import Button from 'react-bootstrap/lib/Button';
 import upperFirst from 'lodash/upperFirst';
 import './styles.less';
 
@@ -53,12 +52,20 @@ export default class ConditionalConfirm extends PureComponent {
         <Modal.Header closeButton={true}>
           <h4>{message}</h4>
           <div className="text-right">
-            <Button onClick={this.handleClose} bsStyle="link">
+            <button
+              type="button"
+              className="btn btn-link"
+              onClick={this.handleClose}
+            >
               {textCancel}
-            </Button>
-            <Button onClick={this.handleConfirm} bsStyle="primary">
+            </button>
+            <button
+              type="button"
+              className="btn btn-primary"
+              onClick={this.handleConfirm}
+            >
               {textConfirm}
-            </Button>
+            </button>
           </div>
         </Modal.Header>
       </Modal>

--- a/src/components/EditField/index.js
+++ b/src/components/EditField/index.js
@@ -1,12 +1,8 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import FormGroup from 'react-bootstrap/lib/FormGroup';
-import Col from 'react-bootstrap/lib/Col';
-import ControlLabel from 'react-bootstrap/lib/ControlLabel';
-import Glyphicon from 'react-bootstrap/lib/Glyphicon';
 import OverlayTrigger from 'react-bootstrap/lib/OverlayTrigger';
 import Popover from 'react-bootstrap/lib/Popover';
-import Label from 'react-bootstrap/lib/Label';
 import { getModelMessage, getFieldLabel } from '../lib'
 import FieldErrorLabel from '../FieldErrors/FieldErrorLabel';
 import './styles.less';
@@ -102,12 +98,15 @@ export default class EditField extends Component {
 
     return (
       <FormGroup controlId={fieldName} validationState={!readOnly && toggledFieldErrors[fieldName] ? 'error' : null}>
-        <Col componentClass={ControlLabel} sm={labelColumns}>
+        <label
+          htmlFor={fieldName}
+          className={`col-sm-${labelColumns} control-label`}
+        >
           {
             fieldLabel + (required ? '*' : '')
           }
-        </Col>
-        <Col sm={12 - labelColumns}>
+        </label>
+        <div className={`col-sm-${12 - labelColumns}`}>
           {
             fieldTooltip && (
               <span className="field-tooltip">
@@ -126,7 +125,7 @@ export default class EditField extends Component {
                     </Popover>
                   }
                 >
-                  <Glyphicon glyph="info-sign" className='text-muted'/>
+                  <span className="glyphicon glyphicon-info-sign text-muted"></span>
                 </OverlayTrigger>
               </span>
             )
@@ -138,12 +137,12 @@ export default class EditField extends Component {
                 <FieldErrorLabel errors={toggledFieldErrors[fieldName]} fieldName={fieldName}/>
               ) :
               (
-                <Label className="hint">
+                <span className="hint label label-default">
                   <small className="text-muted">{fieldHint || '\u00A0'}</small>
-                </Label>
+                </span>
               )
           }
-        </Col>
+        </div>
       </FormGroup>
     );
   }

--- a/src/components/EditHeading/index.js
+++ b/src/components/EditHeading/index.js
@@ -2,11 +2,6 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import Nav from 'react-bootstrap/lib/Nav';
 import NavItem from 'react-bootstrap/lib/NavItem';
-import Col from 'react-bootstrap/lib/Col';
-import Row from 'react-bootstrap/lib/Row';
-import ButtonGroup from 'react-bootstrap/lib/ButtonGroup';
-import Button from 'react-bootstrap/lib/Button';
-import Glyphicon from 'react-bootstrap/lib/Glyphicon';
 import { getModelMessage, getTabLabel } from '../lib';
 import { VIEW_CREATE } from '../../crudeditor-lib/common/constants';
 import ConfirmUnsavedChanges from '../ConfirmDialog/ConfirmUnsavedChanges';
@@ -72,20 +67,24 @@ export default class EditHeading extends PureComponent {
 
     const arrows = [
       <ConfirmUnsavedChanges showDialog={this.showConfirmDialog} key='arrow-left'>
-        <Button
+        <button
+          type="button"
+          className="btn btn-default"
           disabled={!gotoPreviousInstance}
           onClick={gotoPreviousInstance}
         >
-          <Glyphicon glyph="arrow-left"/>
-        </Button>
+          <span className="glyphicon glyphicon-arrow-left"></span>
+        </button>
       </ConfirmUnsavedChanges>,
       <ConfirmUnsavedChanges showDialog={this.showConfirmDialog} key='arrow-right'>
-        <Button
+        <button
+          type="button"
+          className="btn btn-default"
           disabled={!gotoNextInstance}
           onClick={gotoNextInstance}
         >
-          <Glyphicon glyph="arrow-right"/>
-        </Button>
+          <span className="glyphicon glyphicon-arrow-right"></span>
+        </button>
       </ConfirmUnsavedChanges>
     ]
 
@@ -93,8 +92,8 @@ export default class EditHeading extends PureComponent {
 
     return (<div style={{ marginBottom: '10px' }}>
       <H>
-        <Row>
-          <Col xs={8}>
+        <div className="row">
+          <div className="col-xs-8">
             {title}
             {
               (instanceLabel || viewName === VIEW_CREATE) &&
@@ -102,15 +101,15 @@ export default class EditHeading extends PureComponent {
                 {' / ' + (viewName === VIEW_CREATE ? i18n.getMessage('crudEditor.new.title') : instanceLabel)}
               </small>
             }
-          </Col>
-          <Col xs={4}>
+          </div>
+          <div className="col-xs-4">
             <div style={{ float: "right" }}>
-              <ButtonGroup>
+              <div className="btn-group">
                 {arrows}
-              </ButtonGroup>
+              </div>
             </div>
-          </Col>
-        </Row>
+          </div>
+        </div>
       </H>
 
       {

--- a/src/components/EditTab/index.js
+++ b/src/components/EditTab/index.js
@@ -1,9 +1,5 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import Form from 'react-bootstrap/lib/Form';
-import FormGroup from 'react-bootstrap/lib/FormGroup';
-import Col from 'react-bootstrap/lib/Col';
-import ButtonToolbar from 'react-bootstrap/lib/ButtonToolbar';
 import OperationsBar from '../OperationsBar';
 import FormGrid from '../FormGrid';
 import './styles.less';
@@ -32,24 +28,24 @@ export default class EditTab extends PureComponent {
     return (
       <OperationsBar operations={operations}>
         {buttons => (
-          <Form horizontal={true} onSubmit={this.handleSubmit}>
-            <Col sm={12}>
+          <form className="form-horizontal" onSubmit={this.handleSubmit}>
+            <div className="col-sm-12">
               <FormGrid
                 model={this.props.model}
                 toggledFieldErrors={toggledFieldErrors}
                 toggleFieldErrors={toggleFieldErrors}
               />
-            </Col>
-            <FormGroup>
-              <Col sm={12}>
+            </div>
+            <div className="form-group">
+              <div className="col-sm-12">
                 <div className="form-submit text-right">
-                  <ButtonToolbar className="crud--search-result-listing__action-buttons">
+                  <div role="toolbar" className="btn-toolbar crud--search-result-listing__action-buttons">
                     { buttons }
-                  </ButtonToolbar>
+                  </div>
                 </div>
-              </Col>
-            </FormGroup>
-          </Form>
+              </div>
+            </div>
+          </form>
         )}
       </OperationsBar>
     );

--- a/src/components/ErrorMain/index.js
+++ b/src/components/ErrorMain/index.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import Button from 'react-bootstrap/lib/Button';
 import PropTypes from 'prop-types';
 
 const ErrorMain = ({
@@ -32,9 +31,14 @@ const ErrorMain = ({
       }
       {
         goHome &&
-        <Button bsStyle='link' onClick={goHome} key="Cancel">
+        <button
+          type="button"
+          className="btn btn-link"
+          onClick={goHome}
+          key="Cancel"
+        >
           Home
-        </Button>
+        </button>
       }
     </div>
   );

--- a/src/components/FormGrid/index.js
+++ b/src/components/FormGrid/index.js
@@ -1,7 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Row from 'react-bootstrap/lib/Row';
-import Col from 'react-bootstrap/lib/Col';
 import Section from '../EditSection';
 import Field from '../EditField';
 
@@ -11,12 +9,12 @@ const formGrid = ({ model, toggledFieldErrors, toggleFieldErrors }) => {
   let uniqueKey = 1;
 
   const buildRow = (fields, columnsCnt) => (
-    <Row key={'row-' + ++uniqueKey}>
+    <div className="row" key={'row-' + ++uniqueKey}>
       {
         // Iterating over array [0..(columnsCnt - 1)]
         [...Array(columnsCnt).keys()].map(columnIndex => (
-          <Col
-            sm={Math.floor(12 / columnsCnt)}
+          <div
+            className={`col-sm-${Math.floor(12 / columnsCnt)}`}
             key={'column-' + uniqueKey + '-' + columnIndex}
           >
             {
@@ -38,10 +36,10 @@ const formGrid = ({ model, toggledFieldErrors, toggleFieldErrors }) => {
                   />
                 ))
             }
-          </Col>
+          </div>
         ))
       }
-    </Row>
+    </div>
   );
 
   const buildGrid = (entries, tabColumns) => {

--- a/src/components/OperationsBar/Operation.js
+++ b/src/components/OperationsBar/Operation.js
@@ -1,7 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Glyphicon from 'react-bootstrap/lib/Glyphicon';
-import Button from 'react-bootstrap/lib/Button';
 import MenuItem from 'react-bootstrap/lib/MenuItem';
 import ConfirmDialog from '../ConfirmDialog';
 
@@ -14,7 +12,7 @@ const Operation = ({ icon, handler, title, disabled, dropdown, style, size, conf
 
   const label = icon ? [
     typeof icon === 'string' ?
-      <Glyphicon glyph={icon} key="icon" /> :
+      <span className={`glyphicon glyphicon-${icon}`} key="icon"></span> :
       icon,
     '\u00A0\u00A0',
     title
@@ -28,15 +26,14 @@ const Operation = ({ icon, handler, title, disabled, dropdown, style, size, conf
       </span>
     </MenuItem>
   ) : (
-    <Button
+    <button
+      type={isPrimary ? 'submit' : 'button'}
+      className={`btn btn-${style || 'default'}${size !== 'medium' ? ` btn-${size}` : ''}`}
       disabled={disabled}
       onClick={handler}
-      {...(size !== 'medium' && { bsSize: size })}
-      {...(style !== 'default' && { bsStyle: style })}
-      {...(isPrimary && { type: 'submit' })}
     >
       {label}
-    </Button>
+    </button>
   );
 
   if (!disabled && confirm) {

--- a/src/components/RangeInput/components/StringRangeInput/StringRangeInput.react.js
+++ b/src/components/RangeInput/components/StringRangeInput/StringRangeInput.react.js
@@ -1,8 +1,6 @@
 import React, { PureComponent } from 'react';
 import { findDOMNode } from 'react-dom';
 import PropTypes from 'prop-types';
-import InputGroup from 'react-bootstrap/lib/InputGroup';
-import FormControl from 'react-bootstrap/lib/FormControl';
 import './StringRangeInput.less';
 import { exists, noop } from '../../../lib';
 
@@ -83,25 +81,27 @@ export default class StringRangeInput extends PureComponent {
     const { i18n } = this.context;
 
     return (
-      <InputGroup className="crud--range-input">
-        <FormControl
+      <span className="input-group crud--range-input">
+        <input
           type='text'
+          className="form-control"
           placeholder={i18n.getMessage('crudEditor.range.from')}
           value={exists(value.from) ? value.from : ''}
           onChange={this.handleChange('from')}
           disabled={readOnly}
           {...(readOnly && { tabIndex: -1 })}
         />
-        <InputGroup.Addon className="unselectable">{`\u2013`}</InputGroup.Addon>
-        <FormControl
+        <span className="input-group-addon unselectable">{`\u2013`}</span>
+        <input
           type='text'
+          className="form-control"
           placeholder={i18n.getMessage('crudEditor.range.to')}
           value={exists(value.to) ? value.to : ''}
           onChange={this.handleChange('to')}
           disabled={readOnly}
           {...(readOnly && { tabIndex: -1 })}
         />
-      </InputGroup>
+      </span>
     )
   }
 }

--- a/src/components/SearchBulkOperationsPanel/index.js
+++ b/src/components/SearchBulkOperationsPanel/index.js
@@ -1,7 +1,5 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import Button from 'react-bootstrap/lib/Button';
-
 import ConfirmDialog from '../ConfirmDialog';
 import './SearchBulkOperationsPanel.less';
 
@@ -36,15 +34,14 @@ export default class SearchBulkOperationsPanel extends PureComponent {
           bulkDelete && (
             <div>
               <ConfirmDialog {...bulkDelete.confirm}>
-                <Button
-                  bsSize='sm'
+                <button
+                  type="button"
+                  className="btn btn-sm btn-default"
                   disabled={bulkDelete.disabled}
-                  /* eslint-disable react/jsx-handler-names */
-                  onClick={bulkDelete.handler}
-                  /* eslint-enable react/jsx-handler-names */
+                  onClick={bulkDelete.handler} // eslint-disable-line react/jsx-handler-names
                 >
                   {bulkDelete.title}
-                </Button>
+                </button>
               </ConfirmDialog>
             </div>
           )

--- a/src/components/SearchForm/index.js
+++ b/src/components/SearchForm/index.js
@@ -1,8 +1,6 @@
-import React from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import isEqual from 'lodash/isEqual';
-import Button from 'react-bootstrap/lib/Button';
-import Form from 'react-bootstrap/lib/Form';
 import FormGroup from 'react-bootstrap/lib/FormGroup';
 import ControlLabel from 'react-bootstrap/lib/ControlLabel';
 import { getFieldLabel } from '../lib';
@@ -10,7 +8,7 @@ import FieldErrorLabel from '../FieldErrors/FieldErrorLabel';
 import WithFieldErrors from '../FieldErrors/WithFieldErrorsHOC';
 import './SearchForm.less';
 
-class SearchForm extends React.Component {
+class SearchForm extends Component {
   static propTypes = {
     model: PropTypes.shape({
       data: PropTypes.shape({
@@ -69,7 +67,10 @@ class SearchForm extends React.Component {
     const { i18n } = this.context;
 
     return (
-      <Form horizontal={true} onSubmit={this.handleSubmit} className="clearfix crud--search-form">
+      <form
+        className="form-horizontal clearfix crud--search-form"
+        onSubmit={this.handleSubmit}
+      >
         <div className="crud--search-form__controls">
           {
             searchableFields.map(({ name, component: Component, valuePropName }) => (
@@ -95,22 +96,23 @@ class SearchForm extends React.Component {
           }
         </div>
         <div className="crud--search-form__submit-group">
-          <Button
-            bsStyle='link'
+          <button
+            type="button"
+            className="btn btn-link"
             onClick={resetFormFilter}
           >
             {i18n.getMessage('crudEditor.reset.button')}
-          </Button>
-          <Button
-            bsStyle="primary"
+          </button>
+          <button
             type="submit"
+            className="btn btn-primary"
             ref={ref => (this.submitBtn = ref)}
             disabled={isEqual(formFilter, resultFilter) || this.fieldErrors()}
           >
             {i18n.getMessage('crudEditor.search.button')}
-          </Button>
+          </button>
         </div>
-      </Form>
+      </form>
     );
   }
 }

--- a/src/components/SearchMain/index.js
+++ b/src/components/SearchMain/index.js
@@ -1,9 +1,5 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import Button from 'react-bootstrap/lib/Button';
-import Glyphicon from 'react-bootstrap/lib/Glyphicon';
-import Row from 'react-bootstrap/lib/Row';
-import Col from 'react-bootstrap/lib/Col';
 import Form from '../SearchForm';
 import Result from '../SearchResult';
 import { getModelMessage } from '../lib';
@@ -48,20 +44,21 @@ export default class SearchMain extends PureComponent {
     return (
       <div className="crud--search-main">
         <H>
-          <Row>
-            <Col xs={8}>
+          <div className="row">
+            <div className="col-xs-8">
 
               {getModelMessage({ i18n, key: 'model.name' })}
 
-              <Button
-                bsStyle="link"
+              <button
+                type="button"
+                className="btn btn-link"
                 onClick={toggleSearchForm}
                 title={i18n.getMessage(`crudEditor.search.${hideSearchForm ? 'show' : 'hide'}SearchForm`)}
               >
-                <Glyphicon glyph={`chevron-${hideSearchForm ? 'right' : 'left'}`} className="small"/>
-              </Button>
-            </Col>
-            <Col xs={4}>
+                <span className={`small glyphicon glyphicon-chevron-${hideSearchForm ? 'right' : 'left'}`}></span>
+              </button>
+            </div>
+            <div className="col-xs-4">
               <div style={{ float: "right" }}>
                 {
                   createInstance &&
@@ -74,8 +71,8 @@ export default class SearchMain extends PureComponent {
                   </button>
                 }
               </div>
-            </Col>
-          </Row>
+            </div>
+          </div>
         </H>
 
         <div className="crud--search-main__container">

--- a/src/components/SearchPaginationPanel/PaginationPanel.js
+++ b/src/components/SearchPaginationPanel/PaginationPanel.js
@@ -31,7 +31,7 @@ export default class PaginationPanel extends PureComponent {
       return;
     }
 
-    let maxPage = Math.ceil(totalCount / max);
+    const maxPage = Math.ceil(totalCount / max);
 
     if (page > maxPage) {
       page = maxPage;

--- a/src/components/SearchResultListing/SearchResultButtons.js
+++ b/src/components/SearchResultListing/SearchResultButtons.js
@@ -1,6 +1,5 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import ButtonGroup from 'react-bootstrap/lib/ButtonGroup';
 import OperationsBar from '../OperationsBar';
 
 export default class SearchResultButtons extends PureComponent {
@@ -43,9 +42,9 @@ export default class SearchResultButtons extends PureComponent {
       <OperationsBar operations={operations} onToggleDropdown={this.handleToggleDropdown} size="small">
         {
           buttons => buttons.length ? (
-            <ButtonGroup bsSize="sm" className="crud--search-result-listing__action-buttons">
+            <div className="btn-group btn-group-sm crud--search-result-listing__action-buttons">
               {buttons}
-            </ButtonGroup>
+            </div>
           ) :
             null
         }

--- a/src/components/SearchResultListing/index.js
+++ b/src/components/SearchResultListing/index.js
@@ -2,7 +2,6 @@ import React, { PureComponent } from 'react';
 import { findDOMNode } from 'react-dom';
 import PropTypes from 'prop-types';
 import Table from 'react-bootstrap/lib/Table';
-import Glyphicon from 'react-bootstrap/lib/Glyphicon';
 import Checkbox from 'react-bootstrap/lib/Checkbox';
 import { getFieldLabel } from '../lib';
 import SearchResultButtons from './SearchResultButtons';
@@ -104,11 +103,15 @@ class SearchResultListing extends PureComponent {
                             getFieldLabel({ i18n, name })
                           }
                           {
-                            sortField === name &&
-                            <Glyphicon
-                              className="crud--search-result-listing__sort-icon"
-                              glyph={`arrow-${sortOrder === 'asc' ? 'up' : 'down'}`}
-                            />
+                            sortField === name && (
+                              <span
+                                className={[
+                                  'glyphicon',
+                                  `glyphicon-arrow-${sortOrder === 'asc' ? 'up' : 'down'}`,
+                                  'crud--search-result-listing__sort-icon'
+                                ].join(' ')}
+                              ></span>
+                            )
                           }
                         </a> :
                         getFieldLabel({ i18n, name })

--- a/src/crudeditor-lib/common/workerSagas/delete.js
+++ b/src/crudeditor-lib/common/workerSagas/delete.js
@@ -28,7 +28,7 @@ export default function*({
   try {
     let errors;
 
-    ({ count, errors } = yield call(modelDefinition.api.delete, {
+    ({ count, errors } = yield call(modelDefinition.api.delete, { // eslint-disable-line prefer-const
       instances: instances.map(logicalKeyBuilder)
     }));
 

--- a/src/crudeditor-lib/index.js
+++ b/src/crudeditor-lib/index.js
@@ -96,7 +96,7 @@ export default baseModelDefinition => {
   const prefix = `${appName}.${hash(modelDefinition)}`;
 
   let onTransition = null;
-  let lastState = {};
+  const lastState = {};
 
   class CrudWrapper extends Component {
     static propTypes = {

--- a/src/crudeditor-lib/middleware/notifications/index.js
+++ b/src/crudeditor-lib/middleware/notifications/index.js
@@ -115,7 +115,7 @@ const eventsMiddleware = /* istanbul ignore next */ ({ i18n, modelDefinition }) 
   const getFieldErrorMessages = ({ errors, formLayout, activeTab }) => {
     const tabNames = [];
 
-    let rez = (Array.isArray(errors) ? errors : [errors]).
+    const rez = (Array.isArray(errors) ? errors : [errors]).
       filter(err => err && typeof err === 'object').
       map(({ field, ...err }) => {
         const tabName = (findLayoutByField(formLayout, field) || {}).tab;

--- a/src/crudeditor-lib/views/search/reducer.js
+++ b/src/crudeditor-lib/views/search/reducer.js
@@ -429,7 +429,7 @@ export default /* istanbul ignore next */ (modelDefinition, i18n) => {
     // ███████████████████████████████████████████████████████████████████████████████████████████████████████
 
     } else if (type === INSTANCE_SELECT) {
-      let { instance } = payload;
+      const { instance } = payload;
 
       newStoreStateSlice.selectedInstances = [
         ...storeState.selectedInstances,
@@ -439,7 +439,7 @@ export default /* istanbul ignore next */ (modelDefinition, i18n) => {
     // ███████████████████████████████████████████████████████████████████████████████████████████████████████
 
     } else if (type === INSTANCE_DESELECT) {
-      let { instance } = payload;
+      const { instance } = payload;
       newStoreStateSlice.selectedInstances = storeState.selectedInstances.filter(ins => ins !== instance);
 
     // ███████████████████████████████████████████████████████████████████████████████████████████████████████

--- a/src/demo/client/components/CrudWrapper/lib.js
+++ b/src/demo/client/components/CrudWrapper/lib.js
@@ -11,7 +11,7 @@ export
 
 // ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒
 
-let buildURL = ({ base, query, hash }) => {
+const buildURL = ({ base, query, hash }) => {
     // base  - string,
     // query - object or false - evaluated value (null, undefined, empty string, etc.).
     // hash  - object or false - evaluated value (null, undefined, empty string, etc.).
@@ -60,7 +60,7 @@ let buildURL = ({ base, query, hash }) => {
 
   suffix2arr = suffix => {
     // Input string, ouput array.
-    let suffixArr = suffix.replace(/^\/|\/$/g, '');
+    const suffixArr = suffix.replace(/^\/|\/$/g, '');
     return suffixArr ? suffixArr.split('/') : [];
   },
 

--- a/src/demo/client/index.js
+++ b/src/demo/client/index.js
@@ -21,14 +21,14 @@ function requireAll(requireContext) {
   }));
 }
 
-let icons = requireAll(require.context('@opuscapita/svg-icons/lib', true, /.*\.svg$/));
+const icons = requireAll(require.context('@opuscapita/svg-icons/lib', true, /.*\.svg$/));
 
-let getIcon = (name) => {
+const getIcon = (name) => {
   return icons.filter(icon => icon.name === name)[0].svg;
 }
 
 
-let NavigationElement = (
+const NavigationElement = (
   <Menu
     appName="Supplier Information Manager"
     activeItem={0}

--- a/src/demo/models/contracts/components/ContractReferenceSearch/ReferenceSearchService.js
+++ b/src/demo/models/contracts/components/ContractReferenceSearch/ReferenceSearchService.js
@@ -4,7 +4,7 @@ export default class ReferenceSearchService {
   getData({ contractId, max = 10, offset = 0 }) {
     const contractIds = getContracts().map(({ contractId }) => contractId).sort();
 
-    let result = contractId ?
+    const result = contractId ?
       contractIds.filter(cid => cid.toLowerCase().includes(contractId.toLowerCase())) :
       contractIds;
 

--- a/src/demo/models/contracts/components/ContractReferenceSearch/index.js
+++ b/src/demo/models/contracts/components/ContractReferenceSearch/index.js
@@ -18,9 +18,9 @@ const SERVICE_URL = 'http://some-host:some-port/';
  * Parses Content-range header and returns response count
  */
 function getTotalCount(response) {
-  let range = response.headers['content-range'];
-  let index = range.indexOf('/');
-  let totalCount = range.substring(index + 1);
+  const range = response.headers['content-range'];
+  const index = range.indexOf('/');
+  const totalCount = range.substring(index + 1);
   return parseInt(totalCount, 10);
 }
 

--- a/src/demo/showroom/ContractEditor.SCOPE.react.js
+++ b/src/demo/showroom/ContractEditor.SCOPE.react.js
@@ -8,7 +8,7 @@ import { I18nManager } from '@opuscapita/i18n'
 function getParameterByName(name, url) {
   if (!url) {url = window.location.href;} // eslint-disable-line no-param-reassign
   name = name.replace(/[\[\]]/g, "\\$&"); // eslint-disable-line no-param-reassign
-  let regex = new RegExp("[?&]" + name + "(=([^&#]*)|&|#|$)"),
+  const regex = new RegExp("[?&]" + name + "(=([^&#]*)|&|#|$)"),
     results = regex.exec(url);
   if (!results) {return null;}
   if (!results[2]) {return '';}


### PR DESCRIPTION
Removed `Form`, `Button`, `Glyphicon`, `Row`, `Col` components in favor of plain HTML tags.

The intent was to reduce size of bundle. 

In reality: **minified** bundle with all dependencies decreased from `803` to `798` kb -> just 5 kb less.

We need to decide if it's worth it.

#285 