### PR TITLE
Add ability to define pagination options on Search view

### DIFF
--- a/src/components/SearchPaginationPanel/index.js
+++ b/src/components/SearchPaginationPanel/index.js
@@ -2,6 +2,7 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import Dropdown from 'react-bootstrap/lib/Dropdown';
 import MenuItem from 'react-bootstrap/lib/MenuItem';
+import find from 'lodash/find';
 import PaginationPanel from './PaginationPanel';
 import './SearchPaginationPanel.less';
 
@@ -10,7 +11,8 @@ export default class SearchResultPaginationPanel extends PureComponent {
     model: PropTypes.shape({
       data: PropTypes.shape({
         pageParams: PropTypes.shape({
-          max: PropTypes.number
+          max: PropTypes.number,
+          offset: PropTypes.number
         }),
         totalCount: PropTypes.number,
         gotoPage: PropTypes.string
@@ -20,7 +22,7 @@ export default class SearchResultPaginationPanel extends PureComponent {
   }
 
   static contextTypes = {
-    i18n: PropTypes.object
+    i18n: PropTypes.object.isRequired
   };
 
   handlePaginate = activePage => this.props.model.actions.searchInstances({
@@ -37,7 +39,8 @@ export default class SearchResultPaginationPanel extends PureComponent {
         pageParams: {
           max,
           offset
-        }
+        },
+        paginationOptions
       },
       actions: { updateGotoPage }
     } = this.props.model;
@@ -56,15 +59,14 @@ export default class SearchResultPaginationPanel extends PureComponent {
             <Dropdown.Toggle>
               {i18n.getMessage('crudEditor.search.resultsPerPage')}
               {':\u0020'}
-              <b>{max === -1 ? i18n.getMessage('crudEditor.search.all') : max}</b>
+              <b>{find(paginationOptions, opt => opt.max === max).label}</b>
             </Dropdown.Toggle>
             <Dropdown.Menu>
-              <MenuItem eventKey={-1} active={max === -1}>All</MenuItem>
-              <MenuItem eventKey={1000} active={max === 1000}>1000</MenuItem>
-              <MenuItem eventKey={100} active={max === 100}>100</MenuItem>
-              <MenuItem eventKey={50} active={max === 50}>50</MenuItem>
-              <MenuItem eventKey={30} active={max === 30}>30</MenuItem>
-              <MenuItem eventKey={10} active={max === 10}>10</MenuItem>
+              {
+                paginationOptions.map(({ max: value, label }) => (
+                  <MenuItem key={value} eventKey={value} active={max === value}>{label}</MenuItem>
+                ))
+              }
             </Dropdown.Menu>
           </Dropdown>
         </div>

--- a/src/components/SearchPaginationPanel/index.js
+++ b/src/components/SearchPaginationPanel/index.js
@@ -40,7 +40,7 @@ export default class SearchResultPaginationPanel extends PureComponent {
           max,
           offset
         },
-        paginationOptions
+        pagination
       },
       actions: { updateGotoPage }
     } = this.props.model;
@@ -59,11 +59,11 @@ export default class SearchResultPaginationPanel extends PureComponent {
             <Dropdown.Toggle>
               {i18n.getMessage('crudEditor.search.resultsPerPage')}
               {':\u0020'}
-              <b>{find(paginationOptions, opt => opt.max === max).label}</b>
+              <b>{find(pagination.options, opt => opt.max === max).label}</b>
             </Dropdown.Toggle>
             <Dropdown.Menu>
               {
-                paginationOptions.map(({ max: value, label }) => (
+                pagination.options.map(({ max: value, label }) => (
                   <MenuItem key={value} eventKey={value} active={max === value}>{label}</MenuItem>
                 ))
               }

--- a/src/crudeditor-lib/check-model/searchUi.js
+++ b/src/crudeditor-lib/check-model/searchUi.js
@@ -46,6 +46,24 @@ const searchUiPropTypes = /* istanbul ignore next */ fieldsMeta => ({
         `);
       }
     }
+  ),
+  pagination: allPropTypes(
+    PropTypes.shape({
+      defaultMax: PropTypes.number,
+      options: PropTypes.arrayOf(PropTypes.shape({
+        max: PropTypes.number,
+        label: PropTypes.string
+      }))
+    }),
+    (props, propName, componentName) => { // eslint-disable-line consistent-return
+      const pagination = props[propName];
+
+      if (pagination && pagination.options.findIndex(({ max }) => max === pagination.defaultMax) === -1) {
+        return new Error(`${componentName}:
+          pagination.defaultMax "${props[propName].defaultMax}" should be equal to one of "max" in pagination.options
+        `);
+      }
+    }
   )
 })
 

--- a/src/crudeditor-lib/index.js
+++ b/src/crudeditor-lib/index.js
@@ -92,13 +92,6 @@ export {
 const appName = 'crudEditor';
 
 export default baseModelDefinition => {
-  const modelDefinition = fillDefaults(baseModelDefinition);
-
-  // Since "object-hash" package does not support async functions, remove them from modelDefinition.
-  // For more details see
-  // https://github.com/puleos/object-hash/issues/67
-  const prefix = `${appName}.${hash(JSON.parse(JSON.stringify(modelDefinition)))}`;
-
   let onTransition = null;
   let lastState = {};
 
@@ -134,6 +127,16 @@ export default baseModelDefinition => {
 
       // core crud translations
       this.context.i18n.register(appName, crudTranslations);
+
+      const modelDefinition = fillDefaults({ baseModelDefinition, i18n: this.context.i18n });
+
+      // modelDefinition also needs to be accessed outside of constructor scope, therefore pin it to 'this'
+      this.modelDefinition = modelDefinition;
+
+      // Since "object-hash" package does not support async functions, remove them from modelDefinition.
+      // For more details see
+      // https://github.com/puleos/object-hash/issues/67
+      const prefix = `${appName}.${hash(JSON.parse(JSON.stringify(modelDefinition)))}`;
 
       // model translations
       const prefixedTranslations = getPrefixedTranslations(modelDefinition.model.translations, prefix);
@@ -208,7 +211,7 @@ export default baseModelDefinition => {
         name = DEFAULT_VIEW,
         state = {}
       } = {}
-    }) => !isEqual(storeState2appState(this.store.getState(), modelDefinition), { name, state })
+    }) => !isEqual(storeState2appState(this.store.getState(), this.modelDefinition), { name, state })
 
     componentWillUnmount() {
       this.runningSaga.cancel()
@@ -219,7 +222,7 @@ export default baseModelDefinition => {
         <Main
           viewName={this.props.view ? this.props.view.name : undefined}
           viewState={this.props.view ? this.props.view.state : undefined}
-          modelDefinition={modelDefinition}
+          modelDefinition={this.modelDefinition}
           externalOperations={this.props.externalOperations}
           uiConfig={this.props.uiConfig}
         />

--- a/src/crudeditor-lib/lib.js
+++ b/src/crudeditor-lib/lib.js
@@ -77,7 +77,7 @@ export function isAllowed(permissions, operation, data) { // eslint-disable-line
 }
 
 // Filling modelDefinition with default values where necessary.
-export function fillDefaults(baseModelDefinition) {
+export function fillDefaults({ baseModelDefinition, i18n }) {
   const modelDefinition = cloneDeep(baseModelDefinition);
 
   // validate modelDefinition using 'prop-types'
@@ -129,7 +129,7 @@ export function fillDefaults(baseModelDefinition) {
 
   Object.keys(getUi).forEach(viewName => {
     if (getUi[viewName]) {
-      modelDefinition.ui[viewName] = getUi[viewName](modelDefinition);
+      modelDefinition.ui[viewName] = getUi[viewName]({ modelDefinition, i18n });
     }
   });
 

--- a/src/crudeditor-lib/views/create/index.js
+++ b/src/crudeditor-lib/views/create/index.js
@@ -3,7 +3,7 @@ import { buildFormLayout } from '../lib';
 
 export { getViewState } from './selectors';
 
-export const getUi = modelDefinition => {
+export const getUi = ({ modelDefinition }) => {
   const createMeta = modelDefinition.ui.create || {};
 
   if (!createMeta.defaultNewInstance) {

--- a/src/crudeditor-lib/views/create/index.spec.js
+++ b/src/crudeditor-lib/views/create/index.spec.js
@@ -17,7 +17,7 @@ describe('create view / index / getUi', () => {
   }
 
   it('should generate proper ui', () => {
-    const result = getUi(modelDefinition)
+    const result = getUi({ modelDefinition })
 
     expect(result).to.have.ownProperty('defaultNewInstance');
     expect(result).to.have.ownProperty('formLayout');

--- a/src/crudeditor-lib/views/edit/index.js
+++ b/src/crudeditor-lib/views/edit/index.js
@@ -3,7 +3,7 @@ import { buildFormLayout } from '../lib';
 
 export { getViewState } from './selectors';
 
-export const getUi = modelDefinition => {
+export const getUi = ({ modelDefinition }) => {
   const editMeta = modelDefinition.ui.edit || {};
 
   editMeta.formLayout = buildFormLayout({

--- a/src/crudeditor-lib/views/edit/index.spec.js
+++ b/src/crudeditor-lib/views/edit/index.spec.js
@@ -17,7 +17,7 @@ describe('edit view / index / getUi', () => {
   }
 
   it('should generate proper ui', () => {
-    const result = getUi(modelDefinition)
+    const result = getUi({ modelDefinition })
     expect(result).to.have.ownProperty('formLayout');
     expect(result.formLayout).to.be.instanceof(Function);
   })

--- a/src/crudeditor-lib/views/edit/workerSagas/save.spec.js
+++ b/src/crudeditor-lib/views/edit/workerSagas/save.spec.js
@@ -31,7 +31,10 @@ const arg = {
         defaultNewInstance
       },
       search: {
-        resultFields: [{ name: 'a' }]
+        resultFields: [{ name: 'a' }],
+        pagination: {
+          defaultMax: 30
+        }
       }
     },
     permissions: {
@@ -62,7 +65,7 @@ const getState = _ => ({
     [VIEW_SEARCH]: {
       pageParams: {},
       sortParams: {},
-      resultFilter: {}
+      resultFilter: {},
     }
   }
 })

--- a/src/crudeditor-lib/views/edit/workerSagas/save.spec.js
+++ b/src/crudeditor-lib/views/edit/workerSagas/save.spec.js
@@ -65,7 +65,7 @@ const getState = _ => ({
     [VIEW_SEARCH]: {
       pageParams: {},
       sortParams: {},
-      resultFilter: {},
+      resultFilter: {}
     }
   }
 })

--- a/src/crudeditor-lib/views/search/constants.js
+++ b/src/crudeditor-lib/views/search/constants.js
@@ -5,7 +5,6 @@ const namespace = VIEW_SEARCH;
 export const
   VIEW_NAME = VIEW_SEARCH,
 
-  DEFAULT_MAX = 30,
   DEFAULT_OFFSET = 0,
   DEFAULT_ORDER = 'asc',
 

--- a/src/crudeditor-lib/views/search/index.js
+++ b/src/crudeditor-lib/views/search/index.js
@@ -29,7 +29,7 @@ const rangeFieldType = {
   [FIELD_TYPE_STRING_DECIMAL]: FIELD_TYPE_STRING_DECIMAL_RANGE
 };
 
-export const getUi = modelDefinition => {
+export const getUi = ({ modelDefinition, i18n }) => {
   const fieldsMeta = modelDefinition.model.fields;
 
   const searchMeta = modelDefinition.ui.search ?
@@ -42,6 +42,20 @@ export const getUi = modelDefinition => {
 
   if (!searchMeta.searchableFields) {
     searchMeta.searchableFields = Object.keys(fieldsMeta).map(name => ({ name }));
+  }
+
+  if (!searchMeta.pagination) {
+    searchMeta.pagination = {
+      defaultMax: 30,
+      options: [
+        { max: -1, label: i18n.getMessage('crudEditor.search.all') },
+        { max: 1000, label: '1000' },
+        { max: 100, label: '100' },
+        { max: 50, label: '50' },
+        { max: 30, label: '30' },
+        { max: 10, label: '10' }
+      ]
+    }
   }
 
   checkSearchUi({ searchMeta, fieldsMeta });

--- a/src/crudeditor-lib/views/search/index.spec.js
+++ b/src/crudeditor-lib/views/search/index.spec.js
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import { I18nManager } from '@opuscapita/i18n';
 import { getUi } from './';
 import { DEFAULT_FIELD_TYPE } from '../../common/constants';
 
@@ -16,8 +17,10 @@ describe('search view / index / getUi', () => {
     ui: {}
   }
 
+  const i18n = new I18nManager();
+
   it('should generate proper ui', () => {
-    const result = getUi(modelDefinition)
+    const result = getUi({ modelDefinition, i18n })
     expect(result).to.have.ownProperty('resultFields');
     expect(result).to.have.ownProperty('searchableFields');
 

--- a/src/crudeditor-lib/views/search/reducer.js
+++ b/src/crudeditor-lib/views/search/reducer.js
@@ -11,7 +11,6 @@ import {
 } from './lib';
 
 import {
-  DEFAULT_MAX,
   DEFAULT_OFFSET,
   DEFAULT_ORDER,
 
@@ -134,7 +133,7 @@ export const buildDefaultStoreState = modelDefinition => ({
     order: DEFAULT_ORDER
   },
   pageParams: {
-    max: DEFAULT_MAX,
+    max: modelDefinition.ui.search.pagination.defaultMax,
     offset: DEFAULT_OFFSET
   },
   gotoPage: '',

--- a/src/crudeditor-lib/views/search/reducer.spec.js
+++ b/src/crudeditor-lib/views/search/reducer.spec.js
@@ -1,7 +1,6 @@
 import { assert } from 'chai';
 import { buildDefaultStoreState } from './reducer';
 import {
-  DEFAULT_MAX,
   DEFAULT_OFFSET,
   DEFAULT_ORDER
 } from './constants';
@@ -33,7 +32,10 @@ describe('search view reducer', () => {
           ],
           resultFields: [
             ...fields
-          ]
+          ],
+          pagination: {
+            defaultMax: 30
+          }
         }
       }
     }
@@ -66,7 +68,7 @@ describe('search view reducer', () => {
             order: DEFAULT_ORDER
           },
           pageParams: {
-            max: DEFAULT_MAX,
+            max: modelDefinition.ui.search.pagination.defaultMax,
             offset: DEFAULT_OFFSET
           },
           selectedInstances: [],

--- a/src/crudeditor-lib/views/search/selectors.js
+++ b/src/crudeditor-lib/views/search/selectors.js
@@ -5,7 +5,6 @@ import {
   getDefaultSortField
 } from './lib';
 import {
-  DEFAULT_MAX,
   DEFAULT_OFFSET,
   DEFAULT_ORDER,
 
@@ -45,7 +44,7 @@ const _getViewState = ({
     ...(filter ? { filter } : {}),
     ...(sort === getDefaultSortField(searchMeta) ? {} : { sort }),
     ...(order === DEFAULT_ORDER ? {} : { order }),
-    ...(max === DEFAULT_MAX ? {} : { max }),
+    ...(max === searchMeta.pagination.defaultMax ? {} : { max }),
     ...(offset === DEFAULT_OFFSET ? {} : { offset })
   };
 };
@@ -81,7 +80,10 @@ export const
       spinner,
       search: {
         resultFields,
-        searchableFields
+        searchableFields,
+        pagination: {
+          options: paginationOptions
+        }
       }
     }
   }) => ({
@@ -124,5 +126,6 @@ export const
     status: storeState.status,
     totalCount: _getTotalCount(storeState),
     hideSearchForm: storeState.hideSearchForm,
-    gotoPage: storeState.gotoPage
+    gotoPage: storeState.gotoPage,
+    paginationOptions
   }));

--- a/src/crudeditor-lib/views/search/selectors.js
+++ b/src/crudeditor-lib/views/search/selectors.js
@@ -81,9 +81,7 @@ export const
       search: {
         resultFields,
         searchableFields,
-        pagination: {
-          options: paginationOptions
-        }
+        pagination
       }
     }
   }) => ({
@@ -127,5 +125,5 @@ export const
     totalCount: _getTotalCount(storeState),
     hideSearchForm: storeState.hideSearchForm,
     gotoPage: storeState.gotoPage,
-    paginationOptions
+    pagination
   }));

--- a/src/crudeditor-lib/views/show/index.js
+++ b/src/crudeditor-lib/views/show/index.js
@@ -3,7 +3,7 @@ import { buildFormLayout } from '../lib';
 
 export { getViewState } from './selectors';
 
-export const getUi = modelDefinition => {
+export const getUi = ({ modelDefinition }) => {
   const showMeta = modelDefinition.ui.show || {};
 
   showMeta.formLayout = buildFormLayout({

--- a/src/crudeditor-lib/views/show/index.spec.js
+++ b/src/crudeditor-lib/views/show/index.spec.js
@@ -17,7 +17,7 @@ describe('show view / index / getUi', () => {
   }
 
   it('should generate proper ui', () => {
-    const result = getUi(modelDefinition)
+    const result = getUi({ modelDefinition })
     expect(result).to.have.ownProperty('formLayout');
     expect(result.formLayout).to.be.instanceof(Function);
   })

--- a/src/demo/models/second-model/index.js
+++ b/src/demo/models/second-model/index.js
@@ -366,7 +366,20 @@ export default {
         { name: 'extContractId', sortable: true },
         { name: 'extContractLineId', sortable: true },
         { name: 'testNumberTypeField', textAlignment: 'right' }
-      ]
+      ],
+      /**
+       * custom pagination settings can be defined like this.
+       * 'pagination' should be either missing or fully defined
+       * (no partial definitions are allowed, e.g. only 'defaultMax' gonna break)
+       */
+      pagination: {
+        defaultMax: 10,
+        options: [
+          { max: 10, label: '10' },
+          { max: 20, label: '20' },
+          { max: 30, label: '30' },
+        ]
+      }
     }),
     instanceLabel: /* istanbul ignore next */ instance => instance._objectLabel || instance.contractId || '',
     create: {


### PR DESCRIPTION
#301 

Also fixes #296 

Pagination options can be defined in model definition (`ui.search().pagination`): 

https://github.com/OpusCapita/react-crudeditor/blob/1f272f4e08fee8b7356e0a3c809686a425aca6c2/src/demo/models/second-model/index.js#L370-L382

If `pagination` is not specified in `ui.search()` then default logic remains the same as it was previously: 

https://github.com/OpusCapita/react-crudeditor/blob/1f272f4e08fee8b7356e0a3c809686a425aca6c2/src/crudeditor-lib/views/search/index.js#L48-L58